### PR TITLE
fix: rosetta default fixture cannot be edited

### DIFF
--- a/src/rosetta.ts
+++ b/src/rosetta.ts
@@ -1,4 +1,4 @@
-import { Component, TextFile } from 'projen';
+import { Component, SampleFile } from 'projen';
 import { TypeScriptProject } from 'projen/lib/typescript';
 
 /**
@@ -17,10 +17,8 @@ export class Rosetta extends Component {
     });
     project.postCompileTask.spawn(rosettaTask);
     project.addGitIgnore('.jsii.tabl.json');
-
-    new TextFile(project, 'rosetta/default.ts-fixture', {
-      readonly: false,
-      lines: [
+    new SampleFile(project, 'rosetta/default.ts-fixture', {
+      contents: [
         '// Fixture with packages imported, but nothing else',
         "import { Construct } from 'constructs';",
         'import {',
@@ -34,8 +32,8 @@ export class Rosetta extends Component {
         '    /// here',
         '  }',
         '}',
-      ],
-      marker: false,
+      ].join('\n'),
     });
+    project.addGitIgnore('!/rosetta/default.ts-fixture');
   }
 }

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -254,7 +254,6 @@ Object {
 /API.md linguist-generated
 /LICENSE linguist-generated
 /package.json linguist-generated
-/rosetta/default.ts-fixture linguist-generated
 /tsconfig.dev.json linguist-generated
 /yarn.lock linguist-generated",
   ".github/pull_request_template.md": "Fixes #",

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -255,7 +255,6 @@ Object {
 /API.md linguist-generated
 /LICENSE linguist-generated
 /package.json linguist-generated
-/rosetta/default.ts-fixture linguist-generated
 /tsconfig.dev.json linguist-generated
 /yarn.lock linguist-generated",
   ".github/pull_request_template.md": "Fixes #",


### PR DESCRIPTION
Currently `default.ts-fixture` is a `TextFile`, which means that it is fully managed by Projen and Projen will revert the file back to it's state despite setting the `TextFile` as `readonly: false`. So consumers of the type can modify `default.ts-fixture`, but it will always be reverted the next time Projen updates itself.

Changing the file to a `SampleFile` solves this problem, as the file will only be committed if it does not exist already. This will allow for consumers' customization of `default.ts-fixture`, which was the intended behavior.