### PR TITLE
fix: dependencies added by integ-runner should use the same cdkVersion as the project

### DIFF
--- a/src/integ-runner.ts
+++ b/src/integ-runner.ts
@@ -1,16 +1,23 @@
-import { Component, DependencyType } from 'projen';
-import { TypeScriptProject } from 'projen/lib/typescript';
+import { awscdk, Component, DependencyType } from 'projen';
 
 /**
  * This component adds support for using `integ-runner` and `integ-tests`
  * in a construct library.
  */
 export class IntegRunner extends Component {
-  constructor(project: TypeScriptProject) {
+  constructor(
+    project: awscdk.AwsCdkConstructLibrary | awscdk.AwsCdkTypeScriptApp,
+  ) {
     super(project);
 
-    project.deps.addDependency('@aws-cdk/integ-runner@^2.45.0', DependencyType.DEVENV);
-    project.deps.addDependency('@aws-cdk/integ-tests-alpha@^2.45.0-alpha.0', DependencyType.DEVENV);
+    project.deps.addDependency(
+      `@aws-cdk/integ-runner@${project.cdkVersion}`,
+      DependencyType.DEVENV,
+    );
+    project.deps.addDependency(
+      `@aws-cdk/integ-tests-alpha@${project.cdkVersion}-alpha.0`,
+      DependencyType.DEVENV,
+    );
 
     const integSnapshotTask = project.addTask('integ', {
       description: 'Run integration snapshot tests',

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -774,12 +774,12 @@ tsconfig.json
       Object {
         "name": "@aws-cdk/integ-runner",
         "type": "devenv",
-        "version": "^2.45.0",
+        "version": "^2.1.0",
       },
       Object {
         "name": "@aws-cdk/integ-tests-alpha",
         "type": "devenv",
-        "version": "^2.45.0-alpha.0",
+        "version": "^2.1.0-alpha.0",
       },
       Object {
         "name": "@types/babel__traverse",
@@ -1363,8 +1363,8 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "organization": false,
     },
     "devDependencies": Object {
-      "@aws-cdk/integ-runner": "^2.45.0",
-      "@aws-cdk/integ-tests-alpha": "^2.45.0-alpha.0",
+      "@aws-cdk/integ-runner": "^2.1.0",
+      "@aws-cdk/integ-tests-alpha": "^2.1.0-alpha.0",
       "@types/jest": "^27",
       "@types/node": "^14",
       "@typescript-eslint/eslint-plugin": "^5",

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -1063,12 +1063,12 @@ tsconfig.json
       Object {
         "name": "@aws-cdk/integ-runner",
         "type": "devenv",
-        "version": "^2.45.0",
+        "version": "^2.1.0",
       },
       Object {
         "name": "@aws-cdk/integ-tests-alpha",
         "type": "devenv",
-        "version": "^2.45.0-alpha.0",
+        "version": "^2.1.0-alpha.0",
       },
       Object {
         "name": "@types/babel__traverse",
@@ -1711,8 +1711,8 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "organization": true,
     },
     "devDependencies": Object {
-      "@aws-cdk/integ-runner": "^2.45.0",
-      "@aws-cdk/integ-tests-alpha": "^2.45.0-alpha.0",
+      "@aws-cdk/integ-runner": "^2.1.0",
+      "@aws-cdk/integ-tests-alpha": "^2.1.0-alpha.0",
       "@types/jest": "^27",
       "@types/node": "^14",
       "@typescript-eslint/eslint-plugin": "^5",


### PR DESCRIPTION
Fixes #