### PR TITLE
fix: setup node and use pre-installed yarn

### DIFF
--- a/src/upgrade-cdklabs-projen-project-types.ts
+++ b/src/upgrade-cdklabs-projen-project-types.ts
@@ -105,8 +105,16 @@ export class UpgradeCdklabsProjenProjectTypes extends Component {
         with: Object.keys(with_).length > 0 ? with_ : undefined,
       },
       {
+        name: 'Setup Node.js',
+        uses: 'actions/setup-node@v3',
+        with: {
+          // @ts-ignore
+          'node-version': this.project.nodeVersion,
+        },
+      },
+      {
         name: 'Install dependencies',
-        run: 'npm install -g yarn && yarn install --check-files --frozen-lockfile',
+        run: this.project.package.installCommand,
       },
       {
         name: 'Upgrade dependencies',

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -558,8 +558,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
       - name: Install dependencies
-        run: npm install -g yarn && yarn install --check-files --frozen-lockfile
+        run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
         run: npx projen upgrade-cdklabs-projen-project-types
       - name: Find mutations
@@ -2244,8 +2248,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with: {}
       - name: Install dependencies
-        run: npm install -g yarn && yarn install --check-files --frozen-lockfile
+        run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
         run: npx projen upgrade-cdklabs-projen-project-types
       - name: Find mutations
@@ -3762,8 +3769,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with: {}
       - name: Install dependencies
-        run: npm install -g yarn && yarn install --check-files --frozen-lockfile
+        run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
         run: npx projen upgrade-cdklabs-projen-project-types
       - name: Find mutations

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -839,8 +839,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.18.0
       - name: Install dependencies
-        run: npm install -g yarn && yarn install --check-files --frozen-lockfile
+        run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
         run: npx projen upgrade-cdklabs-projen-project-types
       - name: Find mutations
@@ -2902,8 +2906,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.18.0
       - name: Install dependencies
-        run: npm install -g yarn && yarn install --check-files --frozen-lockfile
+        run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
         run: npx projen upgrade-cdklabs-projen-project-types
       - name: Find mutations
@@ -4543,8 +4551,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.18.0
       - name: Install dependencies
-        run: npm install -g yarn && yarn install --check-files --frozen-lockfile
+        run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
         run: npx projen upgrade-cdklabs-projen-project-types
       - name: Find mutations

--- a/test/cdklabs.test.ts
+++ b/test/cdklabs.test.ts
@@ -55,8 +55,15 @@ describe('CdklabsConstructLibrary', () => {
       YAML.parse(outdir['.github/workflows/upgrade-cdklabs-projen-project-types-main.yml']).jobs.upgrade.steps,
     ).toEqual(expect.arrayContaining([
       expect.objectContaining({
+        name: 'Setup Node.js',
+        uses: 'actions/setup-node@v3',
+        with: {
+          'node-version': '14.18.0',
+        },
+      }),
+      expect.objectContaining({
         name: 'Install dependencies',
-        run: 'npm install -g yarn && yarn install --check-files --frozen-lockfile',
+        run: 'yarn install --check-files --frozen-lockfile',
       }),
     ]));
 
@@ -174,8 +181,15 @@ describe('CdklabsTypeScriptProject', () => {
       YAML.parse(outdir['.github/workflows/upgrade-cdklabs-projen-project-types-main.yml']).jobs.upgrade.steps,
     ).toEqual(expect.arrayContaining([
       expect.objectContaining({
+        name: 'Setup Node.js',
+        uses: 'actions/setup-node@v3',
+        with: {
+          'node-version': '14.18.0',
+        },
+      }),
+      expect.objectContaining({
         name: 'Install dependencies',
-        run: 'npm install -g yarn && yarn install --check-files --frozen-lockfile',
+        run: 'yarn install --check-files --frozen-lockfile',
       }),
     ]));
 
@@ -226,8 +240,15 @@ describe('CdklabsJsiiProject', () => {
       YAML.parse(outdir['.github/workflows/upgrade-cdklabs-projen-project-types-main.yml']).jobs.upgrade.steps,
     ).toEqual(expect.arrayContaining([
       expect.objectContaining({
+        name: 'Setup Node.js',
+        uses: 'actions/setup-node@v3',
+        with: {
+          'node-version': '14.18.0',
+        },
+      }),
+      expect.objectContaining({
         name: 'Install dependencies',
-        run: 'npm install -g yarn && yarn install --check-files --frozen-lockfile',
+        run: 'yarn install --check-files --frozen-lockfile',
       }),
     ]));
 


### PR DESCRIPTION
Fixes workflows running in docker containers that cannot install yarn globally.