### PR TITLE
fix(upgrade-cdklabs-projen-project-types): conflicts with other upgrades

### DIFF
--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -566,8 +566,6 @@ jobs:
 name: upgrade-cdklabs-projen-project-types-main
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: 0 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -1301,13 +1299,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn upgrade npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --filter=cdklabs-projen-project-types --upgrade",
+            "exec": "npm-check-updates --filter=cdklabs-projen-project-types,projen --upgrade",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade ",
+            "exec": "yarn upgrade projen",
           },
           Object {
             "exec": "npx projen",
@@ -2279,8 +2277,6 @@ jobs:
 name: upgrade-cdklabs-projen-project-types-main
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: 0 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -2943,13 +2939,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn upgrade npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --filter=cdklabs-projen-project-types --upgrade",
+            "exec": "npm-check-updates --filter=cdklabs-projen-project-types,projen --upgrade",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade ",
+            "exec": "yarn upgrade projen",
           },
           Object {
             "exec": "npx projen",
@@ -3824,8 +3820,6 @@ jobs:
 name: upgrade-cdklabs-projen-project-types-main
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: 0 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -4417,13 +4411,13 @@ junit.xml
             "exec": "yarn upgrade npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --filter=cdklabs-projen-project-types --upgrade",
+            "exec": "npm-check-updates --filter=cdklabs-projen-project-types,projen --upgrade",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade ",
+            "exec": "yarn upgrade projen",
           },
           Object {
             "exec": "npx projen",

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -824,8 +824,6 @@ jobs:
 name: upgrade-cdklabs-projen-project-types-main
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: 0 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -1608,13 +1606,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn upgrade npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --filter=cdklabs-projen-project-types --upgrade",
+            "exec": "npm-check-updates --filter=cdklabs-projen-project-types,projen --upgrade",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade ",
+            "exec": "yarn upgrade projen",
           },
           Object {
             "exec": "npx projen",
@@ -2878,8 +2876,6 @@ jobs:
 name: upgrade-cdklabs-projen-project-types-main
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: 0 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -3595,13 +3591,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn upgrade npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --filter=cdklabs-projen-project-types --upgrade",
+            "exec": "npm-check-updates --filter=cdklabs-projen-project-types,projen --upgrade",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade ",
+            "exec": "yarn upgrade projen",
           },
           Object {
             "exec": "npx projen",
@@ -4510,8 +4506,6 @@ jobs:
 name: upgrade-cdklabs-projen-project-types-main
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: 0 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -5108,13 +5102,13 @@ junit.xml
             "exec": "yarn upgrade npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --filter=cdklabs-projen-project-types --upgrade",
+            "exec": "npm-check-updates --filter=cdklabs-projen-project-types,projen --upgrade",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade ",
+            "exec": "yarn upgrade projen",
           },
           Object {
             "exec": "npx projen",


### PR DESCRIPTION
Removes the scheduled run for `upgrade-cdklabs-projen-project-types`.
This new workflow runs at the same time as the regular upgrade, which also upgrade project types, causing a lot of conflicts with the resulting PRs.

I've had a chat with @kaizencc and we don't think we need to run this separately on a regular basis.
The goal was to have to push an update out without doing other upgrades.
For that we only need a workflow that can be triggered manually.
This can be revised in future. If so, it should run at a different time than the full upgrade to avoid conflicts.

Also makes a change to include `projen` into the upgrade.
Not including projen also caused PRs to fail when a parent project type changed.