### PR TITLE
chore: upgrade dependency acyclic to projen and projects

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 18 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,3 +1,4 @@
+import { javascript } from 'projen';
 import { generateYarnMonorepoOptions } from './projenrc/yarn-monorepo-options';
 import { CdklabsJsiiProject } from './src';
 
@@ -16,6 +17,11 @@ const project = new CdklabsJsiiProject({
   enablePRAutoMerge: true,
   cdklabsPublishingDefaults: false,
   upgradeCdklabsProjenProjectTypes: false, // that is this project!
+  depsUpgradeOptions: {
+    workflowOptions: {
+      schedule: javascript.UpgradeDependenciesSchedule.expressions(['0 18 * * *']),
+    },
+  },
   setNodeEngineVersion: false,
   autoApproveUpgrades: true,
   autoApproveOptions: {


### PR DESCRIPTION
Currently this package and its dependencies run the upgrade at midnight (UTC). This causes depending projects to not receive changes until the next run. Make sure upgrades for this package run before the projects, but after projen.