### PR TITLE
feat: always add a dev dependency on cdklabs-projen-project-types

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -26,4 +26,7 @@ const project = new CdklabsJsiiProject({
 
 generateYarnMonorepoOptions(project);
 
+// that is this package!
+project.deps.removeDependency(project.name);
+
 project.synth();

--- a/src/common-options.ts
+++ b/src/common-options.ts
@@ -110,6 +110,11 @@ export function configureCommonFeatures(project: typescript.TypeScriptProject, o
   if (opts.setNodeEngineVersion === false) {
     project.package.file.addOverride('engines.node', undefined);
   }
+
+  // If cdklabs-projen-project-types is not added explicitly, add it now
+  if (!project.deps.all.some(dep => dep.name === 'cdklabs-projen-project-types')) {
+    project.addDevDeps('cdklabs-projen-project-types');
+  }
 }
 
 function automationUserForOrg(tenancy: OrgTenancy) {

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -827,6 +827,10 @@ tsconfig.json
         "version": "2.1.0",
       },
       Object {
+        "name": "cdklabs-projen-project-types",
+        "type": "build",
+      },
+      Object {
         "name": "constructs",
         "type": "build",
         "version": "10.0.5",
@@ -1305,7 +1309,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade projen",
+            "exec": "yarn upgrade cdklabs-projen-project-types projen",
           },
           Object {
             "exec": "npx projen",
@@ -1542,6 +1546,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "aws-cdk-lib": "2.1.0",
+      "cdklabs-projen-project-types": "*",
       "constructs": "10.0.5",
       "eslint": "^8",
       "eslint-import-resolver-node": "*",
@@ -2527,6 +2532,10 @@ tsconfig.json
         "version": "^5",
       },
       Object {
+        "name": "cdklabs-projen-project-types",
+        "type": "build",
+      },
+      Object {
         "name": "eslint-import-resolver-node",
         "type": "build",
       },
@@ -2945,7 +2954,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade projen",
+            "exec": "yarn upgrade cdklabs-projen-project-types projen",
           },
           Object {
             "exec": "npx projen",
@@ -3179,6 +3188,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
+      "cdklabs-projen-project-types": "*",
       "eslint": "^8",
       "eslint-import-resolver-node": "*",
       "eslint-import-resolver-typescript": "*",
@@ -4067,6 +4077,10 @@ junit.xml
         "version": "^5",
       },
       Object {
+        "name": "cdklabs-projen-project-types",
+        "type": "build",
+      },
+      Object {
         "name": "eslint-import-resolver-node",
         "type": "build",
       },
@@ -4417,7 +4431,7 @@ junit.xml
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade projen",
+            "exec": "yarn upgrade cdklabs-projen-project-types projen",
           },
           Object {
             "exec": "npx projen",
@@ -4646,6 +4660,7 @@ junit.xml
       "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
+      "cdklabs-projen-project-types": "*",
       "eslint": "^8",
       "eslint-import-resolver-node": "*",
       "eslint-import-resolver-typescript": "*",

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -1086,6 +1086,10 @@ tsconfig.json
         "version": "2.1.0",
       },
       Object {
+        "name": "cdklabs-projen-project-types",
+        "type": "build",
+      },
+      Object {
         "name": "constructs",
         "type": "build",
         "version": "10.0.5",
@@ -1612,7 +1616,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade projen",
+            "exec": "yarn upgrade cdklabs-projen-project-types projen",
           },
           Object {
             "exec": "npx projen",
@@ -1849,6 +1853,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "aws-cdk-lib": "2.1.0",
+      "cdklabs-projen-project-types": "*",
       "constructs": "10.0.5",
       "eslint": "^8",
       "eslint-import-resolver-node": "*",
@@ -3131,6 +3136,10 @@ tsconfig.json
         "version": "^5",
       },
       Object {
+        "name": "cdklabs-projen-project-types",
+        "type": "build",
+      },
+      Object {
         "name": "eslint-import-resolver-node",
         "type": "build",
       },
@@ -3597,7 +3606,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade projen",
+            "exec": "yarn upgrade cdklabs-projen-project-types projen",
           },
           Object {
             "exec": "npx projen",
@@ -3831,6 +3840,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "@types/node": "^14",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
+      "cdklabs-projen-project-types": "*",
       "eslint": "^8",
       "eslint-import-resolver-node": "*",
       "eslint-import-resolver-typescript": "*",
@@ -4758,6 +4768,10 @@ junit.xml
         "version": "^5",
       },
       Object {
+        "name": "cdklabs-projen-project-types",
+        "type": "build",
+      },
+      Object {
         "name": "eslint-import-resolver-node",
         "type": "build",
       },
@@ -5108,7 +5122,7 @@ junit.xml
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade projen",
+            "exec": "yarn upgrade cdklabs-projen-project-types projen",
           },
           Object {
             "exec": "npx projen",
@@ -5342,6 +5356,7 @@ junit.xml
       "@types/node": "^14",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
+      "cdklabs-projen-project-types": "*",
       "eslint": "^8",
       "eslint-import-resolver-node": "*",
       "eslint-import-resolver-typescript": "*",


### PR DESCRIPTION
This simplifies migrating to this package.
Checks if the dependency has been added explicitly, and adds itself in if not.
The check allows to depend on a specific version, if necessary.