### PR TITLE
fix: missing upgrade-cdklabs-projen-project-types workflow when release is disabled

### DIFF
--- a/src/upgrade-cdklabs-projen-project-types.ts
+++ b/src/upgrade-cdklabs-projen-project-types.ts
@@ -53,12 +53,17 @@ export class UpgradeCdklabsProjenProjectTypes extends Component {
         { exec: this.project.projenCommand },
       ],
     });
+
+    // Separate workflow for every release branch
     if (Release.of(project)) {
       const release = Release.of(project)!;
       release._forEachBranch(branch => {
         this.createWorkflow(upgradeTask, project.github!, branch);
       });
 
+    // A single workflow
+    } else {
+      this.createWorkflow(upgradeTask, project.github!);
     }
   }
 

--- a/test/cdklabs.test.ts
+++ b/test/cdklabs.test.ts
@@ -161,6 +161,16 @@ describe('CdklabsConstructLibrary', () => {
     expect(autoApprove).toContain('aws-cdk-automation');
     expect(autoApprove).not.toContain('cdklabs-automation');
   });
+
+  describe('with release=false', () => {
+    test('has upgrade-cdklabs-projen-project-types workflow', () => {
+      const project = new TestCdkLabsConstructLibrary({
+        release: false,
+      });
+      const outdir = Testing.synth(project);
+      expect(outdir['.github/workflows/upgrade-cdklabs-projen-project-types.yml']).not.toBeUndefined();
+    });
+  });
 });
 
 describe('CdklabsTypeScriptProject', () => {


### PR DESCRIPTION
Fixes https://github.com/cdklabs/cdk-huggingface missing the workflow.