### PR TITLE
fix: publishing details for namespaced packages are not working

### DIFF
--- a/test/cdklabs.test.ts
+++ b/test/cdklabs.test.ts
@@ -25,6 +25,27 @@ const publishingTargets = {
   },
 };
 
+const namespacedPublishingTargets = {
+  java: {
+    package: 'io.github.cdklabs.test.construct.library',
+    maven: {
+      groupId: 'io.github.cdklabs',
+      artifactId: 'test-construct-library',
+    },
+  },
+  python: {
+    distName: 'cdklabs.test-construct-library',
+    module: 'cdklabs.test_construct_library',
+  },
+  dotnet: {
+    namespace: 'Cdklabs.TestConstructLibrary',
+    packageId: 'Cdklabs.TestConstructLibrary',
+  },
+  go: {
+    moduleName: 'github.com/cdklabs/test-construct-library-go',
+  },
+};
+
 describe('CdklabsConstructLibrary', () => {
   test('synthesizes with default settings', () => {
     const project = new TestCdkLabsConstructLibrary();
@@ -91,6 +112,18 @@ describe('CdklabsConstructLibrary', () => {
       // jsii publishing
       expect(packageJson.jsii?.targets).toEqual(publishingTargets);
     });
+
+    test('works with namespaced package', () => {
+      const project = new TestCdkLabsConstructLibrary({
+        name: '@cdklabs/test-construct-library',
+      });
+      const outdir = Testing.synth(project);
+      const packageJson = outdir['package.json'];
+
+      // jsii publishing
+      expect(packageJson.jsii?.targets).toEqual(namespacedPublishingTargets);
+    });
+
 
     describe('limiting publishing to a subset of languages', () => {
       test('can be done in experimental modules', () => {


### PR DESCRIPTION
For namespaced packages (`@cdklabs/my-package`) we used to create an invalid publishing config like the following example.
As far as I can tell, the `@` and `/` make this config invalid for ALL languages.
Any namespaced package would have to define custom publishing configs to override the invalid config, so it's okay for us to change the default now.

```json
// invalid targets
"targets": {
  "java": {
    "package": "io.github.cdklabs.@cdklabs/cdk.enterprise.iac",
    "maven": {
      "groupId": "io.github.cdklabs",
      "artifactId": "@cdklabs/cdk-enterprise-iac"
    }
  },
  "python": {
    "distName": "@cdklabs/cdk-enterprise-iac",
    "module": "@cdklabs/cdk_enterprise_iac"
  },
  "dotnet": {
    "namespace": "Cdklabs@cdklabs/cdkEnterpriseIac",
    "packageId": "Cdklabs@cdklabs/cdkEnterpriseIac"
  },
  "go": {
    "moduleName": "github.com/cdklabs/@cdklabs/cdk-enterprise-iac-go"
  }
},
```

With this fix, the new (correct) publishing config for namespaced packages will look like this:
```js
  java: {
    package: 'io.github.cdklabs.test.construct.library',
    maven: {
      groupId: 'io.github.cdklabs',
      artifactId: 'test-construct-library',
    },
  },
  python: {
    distName: 'cdklabs.test-construct-library',
    module: 'cdklabs.test_construct_library',
  },
  dotnet: {
    namespace: 'Cdklabs.TestConstructLibrary',
    packageId: 'Cdklabs.TestConstructLibrary',
  },
  go: {
    moduleName: 'github.com/cdklabs/test-construct-library-go',
  },
```