### PR TITLE
fix: cannot explicitly set cdklabs tenancy

### DIFF
--- a/src/common-options.ts
+++ b/src/common-options.ts
@@ -70,7 +70,7 @@ export function withCommonOptionsDefaults<T extends CdkCommonOptions & github.Gi
     mergify: !enablePRAutoMerge,
   };
   const npmAccess = isPrivate ? undefined : javascript.NpmAccess.PUBLIC;
-  const tenancy = options.tenancy ?? options.name.startsWith('@aws-cdk/') ? OrgTenancy.AWS : OrgTenancy.CDKLABS;
+  const tenancy = options.tenancy ?? (options.name.startsWith('@aws-cdk/') ? OrgTenancy.AWS : OrgTenancy.CDKLABS);
   const autoApproveOptions = {
     allowedUsernames: [automationUserForOrg(tenancy), 'dependabot[bot]'],
     secret: 'GITHUB_TOKEN',

--- a/test/cdklabs.test.ts
+++ b/test/cdklabs.test.ts
@@ -195,6 +195,17 @@ describe('CdklabsConstructLibrary', () => {
     expect(autoApprove).not.toContain('cdklabs-automation');
   });
 
+  test('can set tenancy to cdklabs', () => {
+    const project = new TestCdkLabsConstructLibrary({
+      tenancy: OrgTenancy.CDKLABS,
+    });
+    const outdir = Testing.synth(project);
+    const autoApprove = outdir['.github/workflows/auto-approve.yml'];
+
+    expect(autoApprove).toContain('cdklabs-automation');
+    expect(autoApprove).not.toContain('aws-cdk-automation');
+  });
+
   describe('with release=false', () => {
     test('has upgrade-cdklabs-projen-project-types workflow', () => {
       const project = new TestCdkLabsConstructLibrary({


### PR DESCRIPTION
It defaults to cdklabs when not set, so this wasn't a big issue.
