### PR TITLE
fix: releasable commits breaks manual releases

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -267,25 +267,13 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='jsii-rosetta,jsii'"
-        },
-        {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='jsii-rosetta,jsii'"
-        },
-        {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='jsii-rosetta,jsii'"
-        },
-        {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='jsii-rosetta,jsii'"
-        },
-        {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='jsii-rosetta,jsii'"
+          "exec": "npm-check-updates --upgrade --target=minor --filter=@jsii/spec,@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,eslint-import-resolver-node,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,jsii-reflect,npm-check-updates,projen,standard-version,ts-jest,ts-node,typescript,yaml"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @jsii/spec @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-reflect jsii-rosetta jsii npm-check-updates projen standard-version ts-jest ts-node typescript yaml projen projen"
+          "exec": "yarn upgrade @jsii/spec @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-reflect npm-check-updates projen standard-version ts-jest ts-node typescript yaml"
         },
         {
           "exec": "npx projen"


### PR DESCRIPTION
Calling this a fix just in case, since I want to release this library.

Reverting this change because the idea is that we could release manually if necessary, but we cannot. Until I figure out how to fix that, this change allows for the release of this library.

```
 npm notice Publishing to https://registry.npmjs.org/
npm ERR! code E403
npm ERR! 403 403 Forbidden - PUT https://registry.npmjs.org/cdklabs-projen-project-types - You cannot publish over the previously published versions: 0.1.160.
npm ERR! 403 In most cases, you or one of your dependencies are requesting
npm ERR! 403 a package version that is forbidden by your security policy, or
npm ERR! 403 on a server you do not have access to.
```