### PR TITLE
fix: re-enable only releasing features and fixes

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,4 @@
-import { javascript } from 'projen';
+import { ReleasableCommits, javascript } from 'projen';
 import { generateYarnMonorepoOptions } from './projenrc/yarn-monorepo-options';
 import { CdklabsJsiiProject } from './src';
 
@@ -28,6 +28,9 @@ const project = new CdklabsJsiiProject({
     allowedUsernames: ['cdklabs-automation', 'dependabot[bot]'],
     secret: 'GITHUB_TOKEN',
   },
+  // Default is to release only features and fixes. If we don't do this, we'll
+  // release every day because of devDependency updates.
+  releasableCommits: ReleasableCommits.featuresAndFixes(),
 });
 
 generateYarnMonorepoOptions(project);


### PR DESCRIPTION
This reverts commit 338358c27566ec17bb87e1fcd209cfcdedbf13fa.

We've decided that manual release trigger won't work but will create dummy PRs to release this library when necessary from now on.