### PR TITLE
chore: make `projen` dependency floating in projen

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -10,7 +10,7 @@ const project = new CdklabsJsiiProject({
   defaultReleaseBranch: 'main',
   name: 'cdklabs-projen-project-types',
   repositoryUrl: 'https://github.com/cdklabs/cdklabs-projen-project-types.git',
-  devDeps: ['@jsii/spec', 'jsii-reflect', 'projen@0.77.1'],
+  devDeps: ['@jsii/spec', 'jsii-reflect', 'projen'],
   bundledDeps: ['yaml'],
   peerDeps: ['projen'],
   enablePRAutoMerge: true,


### PR DESCRIPTION
It already is floating in `package.json`.
