### PR TITLE
fix: peerDependencies are upgraded without devDependencies

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -267,7 +267,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade yaml constructs projen"
+          "exec": "yarn upgrade yaml"
         },
         {
           "exec": "npx projen"

--- a/src/common-options.ts
+++ b/src/common-options.ts
@@ -124,7 +124,11 @@ export function configureCommonFeatures(project: typescript.TypeScriptProject, o
 
     new javascript.UpgradeDependencies(project, {
       taskName: 'upgrade',
-      types: [DependencyType.RUNTIME, DependencyType.BUNDLED, DependencyType.PEER],
+      // NOTE: we explicitly do NOT upgrade PEER dependencies. We want the widest range of compatibility possible,
+      // and by bumping peer dependencies we force the customer to also unnecessarily upgrade, which they may not want
+      // to do. Never mind that peerDependencies are usually also devDependencies, so it doesn't make sense to upgrade
+      // them without also upgrading devDependencies.
+      types: [DependencyType.RUNTIME, DependencyType.BUNDLED],
       exclude,
       semanticCommit: 'fix',
       workflowOptions: {

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -1336,20 +1336,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           "CI": "0",
         },
         "name": "upgrade",
-        "steps": Array [
-          Object {
-            "exec": "yarn install --check-files",
-          },
-          Object {
-            "exec": "yarn upgrade aws-cdk-lib constructs",
-          },
-          Object {
-            "exec": "npx projen",
-          },
-          Object {
-            "spawn": "post-upgrade",
-          },
-        ],
+        "steps": Array [],
       },
       "upgrade-cdklabs-projen-project-types": Object {
         "description": "upgrade cdklabs-projen-project-types",

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -1646,20 +1646,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           "CI": "0",
         },
         "name": "upgrade",
-        "steps": Array [
-          Object {
-            "exec": "yarn install --check-files",
-          },
-          Object {
-            "exec": "yarn upgrade aws-cdk-lib constructs",
-          },
-          Object {
-            "exec": "npx projen",
-          },
-          Object {
-            "spawn": "post-upgrade",
-          },
-        ],
+        "steps": Array [],
       },
       "upgrade-cdklabs-projen-project-types": Object {
         "description": "upgrade cdklabs-projen-project-types",


### PR DESCRIPTION
This leads to upgrades that immediately fail because the peerDependencies are not satisfied.
