### PR TITLE
fix: upgrade workflow does not work in monorepos

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -264,6 +264,9 @@
       },
       "steps": [
         {
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod,peer --filter=yaml,constructs,projen"
+        },
+        {
           "exec": "yarn install --check-files"
         },
         {
@@ -284,6 +287,9 @@
         "CI": "0"
       },
       "steps": [
+        {
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@jsii/spec,@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,jsii-reflect,projen,standard-version,ts-jest,ts-node,typescript"
+        },
         {
           "exec": "yarn install --check-files"
         },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -264,7 +264,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod,peer --filter=yaml,constructs,projen"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod --filter=yaml"
         },
         {
           "exec": "yarn install --check-files"

--- a/src/safer-upgrades.ts
+++ b/src/safer-upgrades.ts
@@ -1,35 +1,12 @@
 import { Construct } from 'constructs';
-import { Component, JsonPatch } from 'projen';
-import { UpgradeDependencies } from 'projen/lib/javascript';
+import { Component } from 'projen';
 
 export class SaferUpgrades extends Component {
 
   public constructor(scope: Construct) {
     super(scope, 'SaferUpgrades#');
 
-    const tasks = this.project.tryFindObjectFile('.projen/tasks.json');
-    if (!tasks) {
-      return;
-    }
-
-    // Remove the initial upgrade step
-    const upgrades = this.project.components.filter((c): c is UpgradeDependencies => c instanceof UpgradeDependencies);
-    for (const upgrade of upgrades) {
-      tasks.patch(JsonPatch.remove(`/tasks/${upgrade.upgradeTask.name}/steps/0`));
-    }
-
-    // This is some hackery to replace the npm-check-updates command with one that is using npx
-
-    // @ts-ignore
-    const originalSynth = tasks.synthesizeContent;
-    // @ts-ignore
-    tasks.synthesizeContent = (resolver: IResolver): string | undefined => {
-      const content = originalSynth.apply(tasks, [resolver])?.replace(/npm-check-updates --upgrade/g, 'npx npm-check-updates@latest --upgrade');
-
-      // Remove the dependency but only after we have synth'd the tasks
-      this.project.deps.removeDependency('npm-check-updates');
-
-      return content;
-    };
+    // The concept has been proven. This is now built into upstream projen and this project types library automatically
+    console.error('SaferUpgrades is no longer necessary, and can be removed');
   }
 }

--- a/src/yarn/monorepo.ts
+++ b/src/yarn/monorepo.ts
@@ -98,8 +98,9 @@ export class Monorepo extends typescript.TypeScriptProject {
       env: { CI: '0' },
       description: 'Upgrade dependencies in all workspaces',
       steps: [
-        { exec: 'yarn upgrade npm-check-updates' },
-        { exec: 'npm-check-updates --dep=dev,optional,peer,prod,bundle --upgrade --target=minor' },
+        // It is not safe anymore to have 'npm-check-updates' in a Yarn 1 dependency tree, so run it in a separate
+        // tree by using npx.
+        { exec: 'npx npm-check-updates@16 --dep=dev,optional,peer,prod,bundle --upgrade --target=minor' },
         { exec: 'yarn workspaces run check-for-updates' },
         { exec: 'yarn install --check-files' },
         { exec: 'yarn upgrade' },

--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -101,7 +101,7 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject {
         toJSON: () => {
           const steps = upgrades.renderTaskSteps() as TaskStep[];
           return steps.filter(
-            (step) => step.exec && typeof step.exec === 'string' && step.exec?.startsWith('npm-check-updates'),
+            (step) => step.exec && typeof step.exec === 'string' && step.exec?.startsWith('npx npm-check-updates'),
           );
         },
       } as any,

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -962,11 +962,6 @@ tsconfig.json
         "version": "1.x",
       },
       Object {
-        "name": "npm-check-updates",
-        "type": "build",
-        "version": "^16",
-      },
-      Object {
         "name": "projen",
         "type": "build",
       },
@@ -1355,10 +1350,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -1382,16 +1374,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-dev-deps",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,npm-check-updates,projen,standard-version,ts-jest,typescript",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,projen,standard-version,ts-jest,typescript",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-rosetta npm-check-updates projen standard-version ts-jest typescript",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-rosetta projen standard-version ts-jest typescript",
           },
           Object {
             "exec": "npx projen",
@@ -1643,7 +1632,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "jsii-docgen": "*",
       "jsii-pacmak": "*",
       "jsii-rosetta": "*",
-      "npm-check-updates": "^16",
       "projen": "*",
       "standard-version": "^9",
       "ts-jest": "^27",
@@ -2758,11 +2746,6 @@ tsconfig.json
         "version": "1.x",
       },
       Object {
-        "name": "npm-check-updates",
-        "type": "build",
-        "version": "^16",
-      },
-      Object {
         "name": "projen",
         "type": "build",
       },
@@ -3096,10 +3079,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -3123,16 +3103,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-dev-deps",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,npm-check-updates,projen,standard-version,ts-jest,typescript",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,projen,standard-version,ts-jest,typescript",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak npm-check-updates projen standard-version ts-jest typescript",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak projen standard-version ts-jest typescript",
           },
           Object {
             "exec": "npx projen",
@@ -3381,7 +3358,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "jsii-docgen": "*",
       "jsii-pacmak": "*",
       "jsii-rosetta": "1.x",
-      "npm-check-updates": "^16",
       "projen": "*",
       "standard-version": "^9",
       "ts-jest": "^27",
@@ -4377,11 +4353,6 @@ junit.xml
         "version": "^15",
       },
       Object {
-        "name": "npm-check-updates",
-        "type": "build",
-        "version": "^16",
-      },
-      Object {
         "name": "projen",
         "type": "build",
       },
@@ -4665,10 +4636,7 @@ junit.xml
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -4692,16 +4660,13 @@ junit.xml
         "name": "upgrade-dev-deps",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest,jest-junit,npm-check-updates,projen,standard-version,ts-jest,typescript",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest,jest-junit,projen,standard-version,ts-jest,typescript",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit npm-check-updates projen standard-version ts-jest typescript",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit projen standard-version ts-jest typescript",
           },
           Object {
             "exec": "npx projen",
@@ -4940,7 +4905,6 @@ junit.xml
       "eslint-plugin-import": "*",
       "jest": "*",
       "jest-junit": "^15",
-      "npm-check-updates": "^16",
       "projen": "*",
       "standard-version": "^9",
       "ts-jest": "*",

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -1338,6 +1338,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade",
         "steps": Array [
           Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod,peer --filter=aws-cdk-lib,constructs",
+          },
+          Object {
             "exec": "yarn install --check-files",
           },
           Object {
@@ -1359,6 +1362,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
           Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+          },
+          Object {
             "exec": "yarn install --check-files",
           },
           Object {
@@ -1379,6 +1385,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         },
         "name": "upgrade-dev-deps",
         "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,projen,standard-version,ts-jest,typescript",
+          },
           Object {
             "exec": "yarn install --check-files",
           },
@@ -3068,7 +3077,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           "CI": "0",
         },
         "name": "upgrade",
-        "steps": Array [],
+        "steps": Array [
+          Object {
+            "exec": "echo No dependencies to upgrade.",
+          },
+        ],
       },
       "upgrade-cdklabs-projen-project-types": Object {
         "description": "upgrade cdklabs-projen-project-types",
@@ -3077,6 +3090,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         },
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+          },
           Object {
             "exec": "yarn install --check-files",
           },
@@ -3098,6 +3114,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         },
         "name": "upgrade-dev-deps",
         "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,projen,standard-version,ts-jest,typescript",
+          },
           Object {
             "exec": "yarn install --check-files",
           },
@@ -4615,7 +4634,11 @@ junit.xml
           "CI": "0",
         },
         "name": "upgrade",
-        "steps": Array [],
+        "steps": Array [
+          Object {
+            "exec": "echo No dependencies to upgrade.",
+          },
+        ],
       },
       "upgrade-cdklabs-projen-project-types": Object {
         "description": "upgrade cdklabs-projen-project-types",
@@ -4624,6 +4647,9 @@ junit.xml
         },
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+          },
           Object {
             "exec": "yarn install --check-files",
           },
@@ -4645,6 +4671,9 @@ junit.xml
         },
         "name": "upgrade-dev-deps",
         "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest,jest-junit,projen,standard-version,ts-jest,typescript",
+          },
           Object {
             "exec": "yarn install --check-files",
           },

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -341,11 +341,6 @@ tsconfig.tsbuildinfo
         "version": "^10.0.0",
       },
       Object {
-        "name": "npm-check-updates",
-        "type": "build",
-        "version": "^16",
-      },
-      Object {
         "name": "projen",
         "type": "build",
       },
@@ -733,7 +728,6 @@ tsconfig.tsbuildinfo
     "devDependencies": Object {
       "@types/node": "^18",
       "constructs": "^10.0.0",
-      "npm-check-updates": "^16",
       "projen": "*",
       "ts-node": "*",
       "typescript": "*",
@@ -1056,11 +1050,6 @@ tsconfig.tsbuildinfo
         "version": "^15",
       },
       Object {
-        "name": "npm-check-updates",
-        "type": "build",
-        "version": "^16",
-      },
-      Object {
         "name": "prettier",
         "type": "build",
       },
@@ -1128,6 +1117,11 @@ tsconfig.tsbuildinfo
           "CI": "0",
         },
         "name": "check-for-updates",
+        "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,constructs,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,jest,jest-junit,prettier,projen,ts-jest,typescript",
+          },
+        ],
       },
       "compile": Object {
         "description": "Only compile",
@@ -1447,7 +1441,6 @@ tsconfig.tsbuildinfo
       "eslint-plugin-prettier": "*",
       "jest": "*",
       "jest-junit": "^15",
-      "npm-check-updates": "^16",
       "prettier": "*",
       "projen": "*",
       "ts-jest": "*",
@@ -1877,11 +1870,6 @@ tsconfig.tsbuildinfo
         "version": "^15",
       },
       Object {
-        "name": "npm-check-updates",
-        "type": "build",
-        "version": "^16",
-      },
-      Object {
         "name": "prettier",
         "type": "build",
       },
@@ -1949,6 +1937,11 @@ tsconfig.tsbuildinfo
           "CI": "0",
         },
         "name": "check-for-updates",
+        "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,constructs,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,jest,jest-junit,prettier,projen,ts-jest,typescript",
+          },
+        ],
       },
       "compile": Object {
         "description": "Only compile",
@@ -2268,7 +2261,6 @@ tsconfig.tsbuildinfo
       "eslint-plugin-prettier": "*",
       "jest": "*",
       "jest-junit": "^15",
-      "npm-check-updates": "^16",
       "prettier": "*",
       "projen": "*",
       "ts-jest": "*",

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -498,10 +498,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --dep=dev,optional,peer,prod,bundle --upgrade --target=minor",
+            "exec": "npx npm-check-updates@16 --dep=dev,optional,peer,prod,bundle --upgrade --target=minor",
           },
           Object {
             "exec": "yarn workspaces run check-for-updates",
@@ -1120,6 +1117,11 @@ tsconfig.tsbuildinfo
           "CI": "0",
         },
         "name": "check-for-updates",
+        "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,constructs,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,jest,jest-junit,prettier,projen,ts-jest,typescript",
+          },
+        ],
       },
       "compile": Object {
         "description": "Only compile",
@@ -1935,6 +1937,11 @@ tsconfig.tsbuildinfo
           "CI": "0",
         },
         "name": "check-for-updates",
+        "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,constructs,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,jest,jest-junit,prettier,projen,ts-jest,typescript",
+          },
+        ],
       },
       "compile": Object {
         "description": "Only compile",

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -1648,6 +1648,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade",
         "steps": Array [
           Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod,peer --filter=aws-cdk-lib,constructs",
+          },
+          Object {
             "exec": "yarn install --check-files",
           },
           Object {
@@ -1669,6 +1672,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
           Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+          },
+          Object {
             "exec": "yarn install --check-files",
           },
           Object {
@@ -1689,6 +1695,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         },
         "name": "upgrade-dev-deps",
         "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,projen,standard-version,ts-jest,typescript",
+          },
           Object {
             "exec": "yarn install --check-files",
           },
@@ -3820,7 +3829,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           "CI": "0",
         },
         "name": "upgrade",
-        "steps": Array [],
+        "steps": Array [
+          Object {
+            "exec": "echo No dependencies to upgrade.",
+          },
+        ],
       },
       "upgrade-cdklabs-projen-project-types": Object {
         "description": "upgrade cdklabs-projen-project-types",
@@ -3829,6 +3842,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         },
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+          },
           Object {
             "exec": "yarn install --check-files",
           },
@@ -3850,6 +3866,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         },
         "name": "upgrade-dev-deps",
         "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,projen,standard-version,ts-jest,typescript",
+          },
           Object {
             "exec": "yarn install --check-files",
           },
@@ -5415,7 +5434,11 @@ junit.xml
           "CI": "0",
         },
         "name": "upgrade",
-        "steps": Array [],
+        "steps": Array [
+          Object {
+            "exec": "echo No dependencies to upgrade.",
+          },
+        ],
       },
       "upgrade-cdklabs-projen-project-types": Object {
         "description": "upgrade cdklabs-projen-project-types",
@@ -5424,6 +5447,9 @@ junit.xml
         },
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+          },
           Object {
             "exec": "yarn install --check-files",
           },
@@ -5445,6 +5471,9 @@ junit.xml
         },
         "name": "upgrade-dev-deps",
         "steps": Array [
+          Object {
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest,jest-junit,projen,standard-version,ts-jest,typescript",
+          },
           Object {
             "exec": "yarn install --check-files",
           },

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -1222,11 +1222,6 @@ tsconfig.json
         "version": "1.x",
       },
       Object {
-        "name": "npm-check-updates",
-        "type": "build",
-        "version": "^16",
-      },
-      Object {
         "name": "projen",
         "type": "build",
       },
@@ -1665,10 +1660,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -1692,16 +1684,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-dev-deps",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,npm-check-updates,projen,standard-version,ts-jest,typescript",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,projen,standard-version,ts-jest,typescript",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-rosetta npm-check-updates projen standard-version ts-jest typescript",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-rosetta projen standard-version ts-jest typescript",
           },
           Object {
             "exec": "npx projen",
@@ -1953,7 +1942,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "jsii-docgen": "*",
       "jsii-pacmak": "*",
       "jsii-rosetta": "*",
-      "npm-check-updates": "^16",
       "projen": "*",
       "standard-version": "^9",
       "ts-jest": "^27",
@@ -3460,11 +3448,6 @@ tsconfig.json
         "version": "1.x",
       },
       Object {
-        "name": "npm-check-updates",
-        "type": "build",
-        "version": "^16",
-      },
-      Object {
         "name": "projen",
         "type": "build",
       },
@@ -3848,10 +3831,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -3875,16 +3855,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-dev-deps",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,npm-check-updates,projen,standard-version,ts-jest,typescript",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,projen,standard-version,ts-jest,typescript",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak npm-check-updates projen standard-version ts-jest typescript",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak projen standard-version ts-jest typescript",
           },
           Object {
             "exec": "npx projen",
@@ -4133,7 +4110,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "jsii-docgen": "*",
       "jsii-pacmak": "*",
       "jsii-rosetta": "1.x",
-      "npm-check-updates": "^16",
       "projen": "*",
       "standard-version": "^9",
       "ts-jest": "^27",
@@ -5175,11 +5151,6 @@ junit.xml
         "version": "^15",
       },
       Object {
-        "name": "npm-check-updates",
-        "type": "build",
-        "version": "^16",
-      },
-      Object {
         "name": "projen",
         "type": "build",
       },
@@ -5465,10 +5436,7 @@ junit.xml
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -5492,16 +5460,13 @@ junit.xml
         "name": "upgrade-dev-deps",
         "steps": Array [
           Object {
-            "exec": "yarn upgrade npm-check-updates",
-          },
-          Object {
-            "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest,jest-junit,npm-check-updates,projen,standard-version,ts-jest,typescript",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,constructs,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest,jest-junit,projen,standard-version,ts-jest,typescript",
           },
           Object {
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit npm-check-updates projen standard-version ts-jest typescript",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit projen standard-version ts-jest typescript",
           },
           Object {
             "exec": "npx projen",
@@ -5745,7 +5710,6 @@ junit.xml
       "eslint-plugin-import": "*",
       "jest": "*",
       "jest-junit": "^15",
-      "npm-check-updates": "^16",
       "projen": "*",
       "standard-version": "^9",
       "ts-jest": "*",


### PR DESCRIPTION
We are moving to running `npm-check-updates` via `npx`, but forgot a couple of places.

Fixes #