### PR TITLE
fix: package claims to be incompatible with current projen versions

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -108,6 +108,7 @@
     },
     {
       "name": "projen",
+      "version": ">=0.77.2 <1.0.0",
       "type": "peer"
     }
   ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -12,7 +12,7 @@ const project = new CdklabsJsiiProject({
   repositoryUrl: 'https://github.com/cdklabs/cdklabs-projen-project-types.git',
   devDeps: ['@jsii/spec', 'jsii-reflect', 'projen'],
   bundledDeps: ['yaml'],
-  peerDeps: ['projen'],
+  peerDeps: ['projen@>=0.77.2 <1.0.0'],
   enablePRAutoMerge: true,
   cdklabsPublishingDefaults: false,
   upgradeCdklabsProjenProjectTypes: false, // that is this project!

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "constructs": "^10.0.0",
-    "projen": "^0.77.2"
+    "projen": ">=0.77.2 <1.0.0"
   },
   "dependencies": {
     "yaml": "^2.3.4"


### PR DESCRIPTION
https://github.com/cdklabs/cdklabs-projen-project-types/pull/326 stopped upgrading peer dependencies with the explicit goal to define the widest range of compatibility possible, but missed to actually change the peer dependency version constraint to be wide

Fixes failing build on upgrade PRs.