### PR TITLE
fix: release to X jobs are running even when not required

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Check for new commits
         id: git_remote
-        run: OUTPUT_VALUE=$(git ls-remote origin -h ${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
+        run: echo "latest_commit=$(git ls-remote origin -h ${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       contents: write
     outputs:
       latest_commit: ${{ steps.git_remote.outputs.latest_commit }}
+      tag_exists: ${{ steps.check_tag_exists.outputs.exists }}
     env:
       CI: "true"
     steps:
@@ -32,9 +33,12 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: release
         run: npx projen release
+      - name: Check if releasetag already exists
+        id: check_tag_exists
+        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Check for new commits
         id: git_remote
-        run: echo "latest_commit=$(git ls-remote origin -h ${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
+        run: OUTPUT_VALUE=$(git ls-remote origin -h ${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl
@@ -51,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -80,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/src/avoid-release-attempts.ts
+++ b/src/avoid-release-attempts.ts
@@ -33,7 +33,6 @@ export class AvoidReleaseAttempts extends Component {
           id: 'check_tag_exists',
           run: '(git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key \'exists\' to \'$OUTPUT_VALUE\'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key \'exists\' to \'$OUTPUT_VALUE\'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)',
         }),
-        JsonPatch.add('/jobs/release/steps/6/run', 'OUTPUT_VALUE=$(git ls-remote origin -h ${{ github.ref }} | cut -f1) && echo "Setting Output Key \'latest_commit\' to \'$OUTPUT_VALUE\'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT'),
       );
     });
   }

--- a/src/avoid-release-attempts.ts
+++ b/src/avoid-release-attempts.ts
@@ -1,0 +1,40 @@
+import { Construct } from 'constructs';
+import { Component, JsonPatch, github, release } from 'projen';
+
+/**
+ * Avoids unnecessary attempts to release a package version if that version already exists as a tag on the repo.
+ *
+ * @internal
+ */
+export class AvoidReleaseAttempts extends Component {
+  public constructor(scope: Construct) {
+    super(scope, 'AvoidReleaseAttempts');
+
+    const releaseBranches = release.Release.of(this.project);
+    const workflowEngine = github.GitHub.of(this.project);
+    if (!releaseBranches || !workflowEngine) {
+      return;
+    }
+
+    // @ts-ignore
+    releaseBranches.publisher.condition = 'needs.release.outputs.tag_exists != \'true\' && needs.release.outputs.latest_commit == github.sha';
+
+    releaseBranches._forEachBranch((branch) => {
+      const workflowName = branch === 'main' ? 'release' : `release-${branch}`;
+      const workflow = workflowEngine.tryFindWorkflow(workflowName)?.file;
+      if (!workflow) {
+        return;
+      }
+
+      workflow.patch(
+        JsonPatch.add('/jobs/release/outputs/tag_exists', '${{ steps.check_tag_exists.outputs.exists }}'),
+        JsonPatch.add('/jobs/release/steps/5', {
+          name: 'Check if releasetag already exists',
+          id: 'check_tag_exists',
+          run: '(git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key \'exists\' to \'$OUTPUT_VALUE\'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key \'exists\' to \'$OUTPUT_VALUE\'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)',
+        }),
+        JsonPatch.add('/jobs/release/steps/6/run', 'OUTPUT_VALUE=$(git ls-remote origin -h ${{ github.ref }} | cut -f1) && echo "Setting Output Key \'latest_commit\' to \'$OUTPUT_VALUE\'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT'),
+      );
+    });
+  }
+}

--- a/src/common-options.ts
+++ b/src/common-options.ts
@@ -1,6 +1,7 @@
 import { DependencyType, github, javascript, typescript } from 'projen';
 import { deepMerge } from 'projen/lib/util';
 import { AutoMergeOptions } from './auto-merge';
+import { AvoidReleaseAttempts } from './avoid-release-attempts';
 import { MergeQueue } from './merge-queue';
 import { Private } from './private';
 import { UpgradeCdklabsProjenProjectTypes } from './upgrade-cdklabs-projen-project-types';
@@ -156,6 +157,8 @@ export function configureCommonFeatures(project: typescript.TypeScriptProject, o
   if (!project.deps.all.some(dep => dep.name === 'cdklabs-projen-project-types')) {
     project.addDevDeps('cdklabs-projen-project-types');
   }
+
+  new AvoidReleaseAttempts(project);
 }
 
 function automationUserForOrg(tenancy: OrgTenancy) {

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -492,7 +492,7 @@ jobs:
         run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Check for new commits
         id: git_remote
-        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
+        run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl
@@ -2290,7 +2290,7 @@ jobs:
         run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
+        run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
@@ -3965,7 +3965,7 @@ jobs:
         run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
+        run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -467,6 +467,7 @@ jobs:
       contents: write
     outputs:
       latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
+      tag_exists: \${{ steps.check_tag_exists.outputs.exists }}
     env:
       CI: "true"
     steps:
@@ -486,9 +487,12 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: release
         run: npx projen release
+      - name: Check if releasetag already exists
+        id: check_tag_exists
+        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Check for new commits
         id: git_remote
-        run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
+        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl
@@ -505,7 +509,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -534,7 +538,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -2262,6 +2266,7 @@ jobs:
       contents: write
     outputs:
       latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
+      tag_exists: \${{ steps.check_tag_exists.outputs.exists }}
     env:
       CI: "true"
     steps:
@@ -2280,9 +2285,12 @@ jobs:
       - name: Check for new commits
         id: git_remote
         run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
+      - name: Check if releasetag already exists
+        id: check_tag_exists
+        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: cd dist && getfacl -R . > permissions-backup.acl
+        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
@@ -2296,7 +2304,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -2325,7 +2333,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -3933,6 +3941,7 @@ jobs:
       contents: write
     outputs:
       latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
+      tag_exists: \${{ steps.check_tag_exists.outputs.exists }}
     env:
       CI: "true"
     steps:
@@ -3951,9 +3960,12 @@ jobs:
       - name: Check for new commits
         id: git_remote
         run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
+      - name: Check if releasetag already exists
+        id: check_tag_exists
+        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: cd dist && getfacl -R . > permissions-backup.acl
+        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
@@ -3967,7 +3979,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -580,6 +580,7 @@ jobs:
       contents: write
     outputs:
       latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
+      tag_exists: \${{ steps.check_tag_exists.outputs.exists }}
     env:
       CI: "true"
     steps:
@@ -599,9 +600,12 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: release
         run: npx projen release
+      - name: Check if releasetag already exists
+        id: check_tag_exists
+        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Check for new commits
         id: git_remote
-        run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
+        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl
@@ -618,7 +622,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -647,7 +651,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -680,7 +684,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-java@v3
         with:
@@ -720,7 +724,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -755,7 +759,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -789,7 +793,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -2787,6 +2791,7 @@ jobs:
       contents: write
     outputs:
       latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
+      tag_exists: \${{ steps.check_tag_exists.outputs.exists }}
     env:
       CI: "true"
     steps:
@@ -2806,9 +2811,12 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: release
         run: npx projen release
+      - name: Check if releasetag already exists
+        id: check_tag_exists
+        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Check for new commits
         id: git_remote
-        run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
+        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl
@@ -2825,7 +2833,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -2854,7 +2862,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -2887,7 +2895,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-java@v3
         with:
@@ -2927,7 +2935,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -2962,7 +2970,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -2996,7 +3004,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -4684,6 +4692,7 @@ jobs:
       contents: write
     outputs:
       latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
+      tag_exists: \${{ steps.check_tag_exists.outputs.exists }}
     env:
       CI: "true"
     steps:
@@ -4703,9 +4712,12 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: release
         run: npx projen release
+      - name: Check if releasetag already exists
+        id: check_tag_exists
+        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Check for new commits
         id: git_remote
-        run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
+        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl
@@ -4722,7 +4734,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: needs.release.outputs.latest_commit == github.sha
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -605,7 +605,7 @@ jobs:
         run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Check for new commits
         id: git_remote
-        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
+        run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl
@@ -2816,7 +2816,7 @@ jobs:
         run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Check for new commits
         id: git_remote
-        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
+        run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl
@@ -4717,7 +4717,7 @@ jobs:
         run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
       - name: Check for new commits
         id: git_remote
-        run: OUTPUT_VALUE=$(git ls-remote origin -h \${{ github.ref }} | cut -f1) && echo "Setting Output Key 'latest_commit' to '$OUTPUT_VALUE'" && echo "latest_commit=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
+        run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl


### PR DESCRIPTION
This only works because registries don't allow publishing over an existing version and publib treats attempts to do so as soft fails.

Hackport from https://github.com/projen/projen/pull/3252 to test this out in a controlled environment.