### PR TITLE
fix(release): avoid release attempts incorrectly block the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,10 @@ jobs:
         run: npx projen release
       - name: Check if releasetag already exists
         id: check_tag_exists
-        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
+        run: |-
+          TAG=$(cat dist/dist/releasetag.txt)
+          ([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin $TAG && (echo "exists=true" >> $GITHUB_OUTPUT)) || echo "exists=false" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
       - name: Check for new commits
         id: git_remote
         run: echo "latest_commit=$(git ls-remote origin -h ${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT

--- a/src/avoid-release-attempts.ts
+++ b/src/avoid-release-attempts.ts
@@ -31,7 +31,11 @@ export class AvoidReleaseAttempts extends Component {
         JsonPatch.add('/jobs/release/steps/5', {
           name: 'Check if releasetag already exists',
           id: 'check_tag_exists',
-          run: '(git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key \'exists\' to \'$OUTPUT_VALUE\'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key \'exists\' to \'$OUTPUT_VALUE\'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)',
+          run: [
+            'TAG=$(cat dist/dist/releasetag.txt)',
+            '([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin $TAG && (echo "exists=true" >> $GITHUB_OUTPUT)) || echo "exists=false" >> $GITHUB_OUTPUT',
+            'cat $GITHUB_OUTPUT',
+          ].join('\n'),
         }),
       );
     });

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -489,7 +489,10 @@ jobs:
         run: npx projen release
       - name: Check if releasetag already exists
         id: check_tag_exists
-        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
+        run: |-
+          TAG=$(cat dist/dist/releasetag.txt)
+          ([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin $TAG && (echo "exists=true" >> $GITHUB_OUTPUT)) || echo "exists=false" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
       - name: Check for new commits
         id: git_remote
         run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
@@ -2287,7 +2290,10 @@ jobs:
         run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
       - name: Check if releasetag already exists
         id: check_tag_exists
-        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
+        run: |-
+          TAG=$(cat dist/dist/releasetag.txt)
+          ([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin $TAG && (echo "exists=true" >> $GITHUB_OUTPUT)) || echo "exists=false" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl
@@ -3962,7 +3968,10 @@ jobs:
         run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
       - name: Check if releasetag already exists
         id: check_tag_exists
-        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
+        run: |-
+          TAG=$(cat dist/dist/releasetag.txt)
+          ([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin $TAG && (echo "exists=true" >> $GITHUB_OUTPUT)) || echo "exists=false" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
       - name: Backup artifact permissions
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -602,7 +602,10 @@ jobs:
         run: npx projen release
       - name: Check if releasetag already exists
         id: check_tag_exists
-        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
+        run: |-
+          TAG=$(cat dist/dist/releasetag.txt)
+          ([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin $TAG && (echo "exists=true" >> $GITHUB_OUTPUT)) || echo "exists=false" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
       - name: Check for new commits
         id: git_remote
         run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
@@ -2813,7 +2816,10 @@ jobs:
         run: npx projen release
       - name: Check if releasetag already exists
         id: check_tag_exists
-        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
+        run: |-
+          TAG=$(cat dist/dist/releasetag.txt)
+          ([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin $TAG && (echo "exists=true" >> $GITHUB_OUTPUT)) || echo "exists=false" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
       - name: Check for new commits
         id: git_remote
         run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
@@ -4714,7 +4720,10 @@ jobs:
         run: npx projen release
       - name: Check if releasetag already exists
         id: check_tag_exists
-        run: (git ls-remote -q --exit-code --tags origin $(cat ./dist/releasetag.txt) && (OUTPUT_VALUE=true && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)) || (OUTPUT_VALUE=false && echo "Setting Output Key 'exists' to '$OUTPUT_VALUE'" && echo "exists=$OUTPUT_VALUE" >> $GITHUB_OUTPUT)
+        run: |-
+          TAG=$(cat dist/dist/releasetag.txt)
+          ([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin $TAG && (echo "exists=true" >> $GITHUB_OUTPUT)) || echo "exists=false" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
       - name: Check for new commits
         id: git_remote
         run: echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
In the CI system, the `releasetag.txt` file ends up in `dist/dist/releasetag.txt` for reasons. 
Also cleans up the output setting to be more resilient and human parseable.