### PR TITLE
fix(yarn-monorepo): gitignore .nx directory

### DIFF
--- a/src/yarn/nx.ts
+++ b/src/yarn/nx.ts
@@ -52,6 +52,8 @@ export class Nx extends Component {
 
     // nx
     project.addDevDeps('nx');
+    project.addGitIgnore('/.nx');
+    project.addPackageIgnore('/.nx');
     new JsonFile(project, 'nx.json', {
       obj: {
         tasksRunnerOptions: {

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -64,6 +64,8 @@ describe('CdkLabsMonorepo', () => {
 
     const outdir = Testing.synth(parent);
     expect(outdir['nx.json']).toMatchSnapshot();
+    expect(outdir['.gitignore']).toContain('/.nx');
+    expect(outdir['.npmignore']).toContain('/.nx');
   });
 
   test('monorepo release', () => {


### PR DESCRIPTION
Fixes `.nx` directory being committed by self-mutation.