### PR TITLE
fix(yarn): monorepo release publish jobs depend on jobs that do not exist

### DIFF
--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -255,7 +255,7 @@ jobs:
     name: "@cdklabs/one: Publish to GitHub Releases"
     needs:
       - release
-      - release_npm
+      - cdklabs-one_release_npm
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -307,7 +307,7 @@ jobs:
     name: "@cdklabs/two: Publish to GitHub Releases"
     needs:
       - release
-      - release_npm
+      - cdklabs-two_release_npm
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -1,4 +1,5 @@
 import { Testing } from 'projen/lib/testing';
+import * as YAML from 'yaml';
 import { yarn } from '../src';
 
 describe('CdkLabsMonorepo', () => {
@@ -86,6 +87,9 @@ describe('CdkLabsMonorepo', () => {
     });
 
     const outdir = Testing.synth(parent);
+    const releaseWorkflow = YAML.parse(outdir['.github/workflows/release.yml']);
+
+    expect(releaseWorkflow.jobs['cdklabs-one_release_github'].needs).toStrictEqual(['release', 'cdklabs-one_release_npm']);
     expect(outdir).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
A upstream fix in projen https://github.com/projen/projen/pull/3526 causes the YarnMonorepo release to fail.

This is because YarnMonorepo is doing some overly clever manipulation of the release workflow that probably should be pulled into projen core. This PR ports the upstream fix to YarnMonorepo.