### PR TITLE
fix: Failed to validate repository information: package.json: "repository.url" is "", expected to match url from provenance

### DIFF
--- a/src/common-options.ts
+++ b/src/common-options.ts
@@ -67,7 +67,8 @@ export interface CdkCommonOptions {
   readonly tenancy?: OrgTenancy;
 }
 
-export function withCommonOptionsDefaults<T extends CdkCommonOptions & github.GitHubProjectOptions>(options: T): T & Required<CdkCommonOptions> {
+type CommonOptions = CdkCommonOptions & typescript.TypeScriptProjectOptions;
+export function withCommonOptionsDefaults<T extends CommonOptions>(options: T): T & Required<CdkCommonOptions> {
   const isPrivate = options.private ?? true;
   const enablePRAutoMerge = options.enablePRAutoMerge ?? isPrivate;
   const ghAutoMergeOptions = options.ghAutoMergeOptions ?? {
@@ -78,6 +79,8 @@ export function withCommonOptionsDefaults<T extends CdkCommonOptions & github.Gi
   };
   const npmAccess = isPrivate ? undefined : javascript.NpmAccess.PUBLIC;
   const tenancy = options.tenancy ?? (options.name.startsWith('@aws-cdk/') ? OrgTenancy.AWS : OrgTenancy.CDKLABS);
+  const shortname = (options.name.startsWith('@') && options.name.split('/')[1]) || options.name;
+  const repository = options.repository ?? `https://github.com/${tenancy}/${shortname}.git`;
   const autoApproveOptions = {
     allowedUsernames: [automationUserForOrg(tenancy), 'dependabot[bot]'],
     secret: 'GITHUB_TOKEN',
@@ -98,6 +101,7 @@ export function withCommonOptionsDefaults<T extends CdkCommonOptions & github.Gi
       autoApproveOptions,
       depsUpgrade: !upgradeRuntimeDepsAsFix,
       upgradeRuntimeDepsAsFix,
+      repository,
     },
   ]) as T & Required<CdkCommonOptions>;
 }

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -1721,7 +1721,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
     "private": true,
     "repository": {
       "type": "git",
-      "url": "url",
+      "url": "https://github.com/cdklabs/test-construct-library.git",
     },
     "resolutions": {
       "@types/babel__traverse": "7.18.2",
@@ -3463,7 +3463,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
     "private": true,
     "repository": {
       "type": "git",
-      "url": "url",
+      "url": "https://github.com/cdklabs/test-jsii-library.git",
     },
     "resolutions": {
       "@types/babel__traverse": "7.18.2",
@@ -5020,6 +5020,10 @@ junit.xml
     "main": "lib/index.js",
     "name": "test-node-project",
     "private": true,
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/cdklabs/test-node-project.git",
+    },
     "scripts": {
       "build": "npx projen build",
       "bump": "npx projen bump",

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -2046,7 +2046,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
     "private": true,
     "repository": {
       "type": "git",
-      "url": "url",
+      "url": "https://github.com/cdklabs/test-construct-library.git",
     },
     "scripts": {
       "build": "npx projen build",
@@ -4220,7 +4220,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
     "private": true,
     "repository": {
       "type": "git",
-      "url": "url",
+      "url": "https://github.com/cdklabs/test-jsii-project.git",
     },
     "scripts": {
       "build": "npx projen build",
@@ -5807,6 +5807,10 @@ junit.xml
     "main": "lib/index.js",
     "name": "test-node-project",
     "private": true,
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/cdklabs/test-node-project.git",
+    },
     "scripts": {
       "build": "npx projen build",
       "bump": "npx projen bump",

--- a/test/cdk.test.ts
+++ b/test/cdk.test.ts
@@ -78,7 +78,9 @@ describe('CdkTypeScriptProject', () => {
   test('synthesizes with default settings', () => {
     const project = new TestCdkTypeScriptProject();
 
-    expect(Testing.synth(project)).toMatchSnapshot();
+    const snapshot = Testing.synth(project);
+    expect(snapshot['package.json'].repository.url).toBe('https://github.com/cdklabs/test-node-project.git');
+    expect(snapshot).toMatchSnapshot();
   });
 
   test('defaults to private', () => {
@@ -97,9 +99,19 @@ describe('CdkTypeScriptProject', () => {
     const snapshot = Testing.synth(project);
 
     expectNotPrivate(snapshot);
+    expect(snapshot['package.json'].repository.url).toBe('https://github.com/aws/test-construct-library.git');
     expect(snapshot['package.json'].publishConfig).toMatchObject({
       access: 'public',
     });
+  });
+
+  test('can set a custom url to private', () => {
+    const project = new TestCdkTypeScriptProject({
+      repository: 'https://github.com/aws-samples/aws-cdk-examples.git',
+    });
+
+    const snapshot = Testing.synth(project);
+    expect(snapshot['package.json'].repository.url).toBe('https://github.com/aws-samples/aws-cdk-examples.git');
   });
 });
 

--- a/test/cdklabs.test.ts
+++ b/test/cdklabs.test.ts
@@ -193,6 +193,7 @@ describe('CdklabsConstructLibrary', () => {
 
     expect(autoApprove).toContain('aws-cdk-automation');
     expect(autoApprove).not.toContain('cdklabs-automation');
+    expect(outdir['package.json'].repository.url).toBe('https://github.com/aws/test-construct-library.git');
   });
 
   test('can set tenancy to cdklabs', () => {
@@ -204,6 +205,7 @@ describe('CdklabsConstructLibrary', () => {
 
     expect(autoApprove).toContain('cdklabs-automation');
     expect(autoApprove).not.toContain('aws-cdk-automation');
+    expect(outdir['package.json'].repository.url).toBe('https://github.com/cdklabs/test-construct-library.git');
   });
 
   describe('with release=false', () => {


### PR DESCRIPTION
When NPM release provenance is enabled, the package.json file must declare a repository url. By default this url isn't required except for JsiiProjects.

This PR adds a default repository url, computed from the org tenancy and package name.
It's a "best guess", but individual projects can still override the url if needed.