### PR TITLE
fix: `npmAccess` is ignored for `CdkTypeScriptProject`

### DIFF
--- a/src/common-options.ts
+++ b/src/common-options.ts
@@ -31,7 +31,7 @@ export function withCommonOptionsDefaults<T extends ProjectOptions>(options: T):
   const githubOptions: github.GitHubOptions = {
     mergify: !enablePRAutoMerge,
   };
-  const npmAccess = isPrivate ? javascript.NpmAccess.RESTRICTED : javascript.NpmAccess.PUBLIC;
+  const npmAccess = options.npmAccess ?? (isPrivate ? javascript.NpmAccess.RESTRICTED : javascript.NpmAccess.PUBLIC);
   const tenancy = options.tenancy ?? (options.name.startsWith('@aws-cdk/') ? OrgTenancy.AWS : OrgTenancy.CDKLABS);
   const shortname = (options.name.startsWith('@') && options.name.split('/')[1]) || options.name;
   const repository = options.repository ?? `https://github.com/${tenancy}/${shortname}.git`;

--- a/test/cdk.test.ts
+++ b/test/cdk.test.ts
@@ -1,4 +1,5 @@
 import { Stability } from 'projen/lib/cdk';
+import { NpmAccess } from 'projen/lib/javascript';
 import { Testing } from 'projen/lib/testing';
 import { expectPrivate, expectNotPrivate } from './private-helpers';
 import { CdkConstructLibrary, CdkConstructLibraryOptions, CdkJsiiProjectOptions, CdkTypeScriptProject, CdkTypeScriptProjectOptions, CdkJsiiProject } from '../src';
@@ -121,6 +122,16 @@ describe('CdkTypeScriptProject', () => {
     const snapshot = Testing.synth(project);
     expect(snapshot['package.json'].repository.url).toBe('https://github.com/aws-samples/aws-cdk-examples.git');
   });
+
+  test('can set npm access', () => {
+    const project = new TestCdkConstructLibrary({
+      npmAccess: NpmAccess.PUBLIC,
+    });
+
+    const snapshot = Testing.synth(project);
+    expect(snapshot['package.json'].publishConfig.access).toEqual('public');
+  });
+
 });
 
 describe('CdkJsiiProject', () => {


### PR DESCRIPTION
We are ignoring the user provided `npmAccess` configuration. This wasn't really a problem until https://github.com/cdklabs/cdklabs-projen-project-types/pull/614, which changed the default for private packages from `undefined` to `NpmAccess.RESTRICTED`. 

https://github.com/cdklabs/cdklabs-projen-project-types/blob/ca82d8eee4b8ac4d9fbe5ea04e9039238360ed71/src/common-options.ts#L34

While this change (arguably) makes sense, it causes problems with monorepos, where the root package must be private, resulting in the following [error](https://github.com/cdklabs/cdk-cloudformation/actions/runs/10967866796/job/30459544961):

```console
/home/runner/work/cdk-cloudformation/cdk-cloudformation/node_modules/projen/src/javascript/node-package.ts:961
      throw new Error(
            ^
Error: "npmAccess" cannot be RESTRICTED for non-scoped npm package "cdk-cloudformation"
```

With this fix, such projects will be able to configure `npmAccess: NpmAccess.PUBLIC` to avoid this problem.