### PR TITLE
fix(eslint): update `eslintrc.js` to look in right directory

### DIFF
--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -200,12 +200,15 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject {
    * .eslintrc.js will take precedence over the JSON file, it will load the
    * JSON file and patch it with a dynamic directory name that cannot be represented in
    * plain JSON (see https://github.com/projen/projen/issues/2405).
+   *
+   * Since eslint config is loaded with different cwd's depending on whether it's
+   * from the VSCode plugin or from the command line, use absolute paths everywhere.
    */
   protected addEslintRcFix() {
     const eslintRc = new SourceCode(this, '.eslintrc.js');
     eslintRc.line('var path = require(\'path\');');
     eslintRc.line('var fs = require(\'fs\');');
-    eslintRc.line('var contents = fs.readFileSync(\'.eslintrc.json\', { encoding: \'utf-8\' });');
+    eslintRc.line('var contents = fs.readFileSync(`${__dirname}/.eslintrc.json`, { encoding: \'utf-8\' });');
     eslintRc.line('// Strip comments, JSON.parse() doesn\'t like those');
     eslintRc.line('contents = contents.replace(/^\\/\\/.*$/m, \'\');');
     eslintRc.line('var json = JSON.parse(contents);');

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -983,7 +983,7 @@ tsconfig.tsbuildinfo
   },
   "packages/@cdklabs/one/.eslintrc.js": "var path = require('path');
 var fs = require('fs');
-var contents = fs.readFileSync('.eslintrc.json', { encoding: 'utf-8' });
+var contents = fs.readFileSync(\`\${__dirname}/.eslintrc.json\`, { encoding: 'utf-8' });
 // Strip comments, JSON.parse() doesn't like those
 contents = contents.replace(/^\\/\\/.*$/m, '');
 var json = JSON.parse(contents);
@@ -1869,7 +1869,7 @@ tsconfig.tsbuildinfo
   },
   "packages/@cdklabs/two/.eslintrc.js": "var path = require('path');
 var fs = require('fs');
-var contents = fs.readFileSync('.eslintrc.json', { encoding: 'utf-8' });
+var contents = fs.readFileSync(\`\${__dirname}/.eslintrc.json\`, { encoding: 'utf-8' });
 // Strip comments, JSON.parse() doesn't like those
 contents = contents.replace(/^\\/\\/.*$/m, '');
 var json = JSON.parse(contents);
@@ -3677,7 +3677,7 @@ tsconfig.tsbuildinfo
   },
   "packages/@cdklabs/one/.eslintrc.js": "var path = require('path');
 var fs = require('fs');
-var contents = fs.readFileSync('.eslintrc.json', { encoding: 'utf-8' });
+var contents = fs.readFileSync(\`\${__dirname}/.eslintrc.json\`, { encoding: 'utf-8' });
 // Strip comments, JSON.parse() doesn't like those
 contents = contents.replace(/^\\/\\/.*$/m, '');
 var json = JSON.parse(contents);
@@ -4493,7 +4493,7 @@ tsconfig.tsbuildinfo
   },
   "packages/@cdklabs/two/.eslintrc.js": "var path = require('path');
 var fs = require('fs');
-var contents = fs.readFileSync('.eslintrc.json', { encoding: 'utf-8' });
+var contents = fs.readFileSync(\`\${__dirname}/.eslintrc.json\`, { encoding: 'utf-8' });
 // Strip comments, JSON.parse() doesn't like those
 contents = contents.replace(/^\\/\\/.*$/m, '');
 var json = JSON.parse(contents);
@@ -6174,7 +6174,7 @@ tsconfig.tsbuildinfo
   },
   "packages/@cdklabs/one/.eslintrc.js": "var path = require('path');
 var fs = require('fs');
-var contents = fs.readFileSync('.eslintrc.json', { encoding: 'utf-8' });
+var contents = fs.readFileSync(\`\${__dirname}/.eslintrc.json\`, { encoding: 'utf-8' });
 // Strip comments, JSON.parse() doesn't like those
 contents = contents.replace(/^\\/\\/.*$/m, '');
 var json = JSON.parse(contents);


### PR DESCRIPTION
In the eslint VSCode plugin, the working directory in which `eslintrc.js` is loaded is not the project directory, and the JS file fails to load the `.json` file that's right next to it.

Include the directory of the file itself, which is guaranteed to be correct.

Fixes #