### PR TITLE
feat: add new property `mergeBranch` to `AutoMergeOptions`

### DIFF
--- a/API.md
+++ b/API.md
@@ -14821,6 +14821,7 @@ const autoMergeOptions: AutoMergeOptions = { ... }
 | --- | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.AutoMergeOptions.property.allowedUsernames">allowedUsernames</a></code> | <code>string[]</code> | Only pull requests authored by these Github usernames will have auto-merge enabled. |
 | <code><a href="#cdklabs-projen-project-types.AutoMergeOptions.property.labels">labels</a></code> | <code>string[]</code> | Only pull requests with one of this labels will have auto-merge enabled. |
+| <code><a href="#cdklabs-projen-project-types.AutoMergeOptions.property.mergeBranch">mergeBranch</a></code> | <code>string</code> | The branch to auto-merge into. |
 | <code><a href="#cdklabs-projen-project-types.AutoMergeOptions.property.mergeMethod">mergeMethod</a></code> | <code><a href="#cdklabs-projen-project-types.MergeMethod">MergeMethod</a></code> | The method used to auto-merge the PR. |
 | <code><a href="#cdklabs-projen-project-types.AutoMergeOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
 | <code><a href="#cdklabs-projen-project-types.AutoMergeOptions.property.secret">secret</a></code> | <code>string</code> | A GitHub secret name which contains a GitHub Access Token with write permissions for the `pull_request` scope. |
@@ -14850,6 +14851,19 @@ public readonly labels: string[];
 - *Default:* all pull requests are eligible for auto-merge
 
 Only pull requests with one of this labels will have auto-merge enabled.
+
+---
+
+##### `mergeBranch`<sup>Optional</sup> <a name="mergeBranch" id="cdklabs-projen-project-types.AutoMergeOptions.property.mergeBranch"></a>
+
+```typescript
+public readonly mergeBranch: string;
+```
+
+- *Type:* string
+- *Default:* "main"
+
+The branch to auto-merge into.
 
 ---
 

--- a/src/auto-merge.ts
+++ b/src/auto-merge.ts
@@ -44,6 +44,13 @@ export interface AutoMergeOptions {
    * @default ["ubuntu-latest"]
    */
   readonly runsOn?: string[];
+
+  /**
+   * The branch to auto-merge into.
+   *
+   * @default "main"
+   */
+  readonly mergeBranch?: string;
 }
 
 /**

--- a/src/common-options.ts
+++ b/src/common-options.ts
@@ -25,8 +25,9 @@ type ConfiguredCommonOptions = Required<CdkCommonOptions &ConfiguredTypeScriptOp
 export function withCommonOptionsDefaults<T extends ProjectOptions>(options: T): T & ConfiguredCommonOptions {
   const isPrivate = options.private ?? true;
   const enablePRAutoMerge = options.enablePRAutoMerge ?? isPrivate;
-  const ghAutoMergeOptions = options.ghAutoMergeOptions ?? {
+  const ghAutoMergeOptions = {
     secret: 'PROJEN_GITHUB_TOKEN',
+    ...options.ghAutoMergeOptions,
   };
   const githubOptions: github.GitHubOptions = {
     mergify: !enablePRAutoMerge,

--- a/src/merge-queue.ts
+++ b/src/merge-queue.ts
@@ -33,7 +33,7 @@ export class MergeQueue extends Component {
     super(project);
 
     const autoMerge = options.autoMerge ?? true;
-    const mergeBranch = options.mergeBranch ?? 'main';
+    const mergeBranch = options.mergeBranch ?? options.autoMergeOptions?.mergeBranch ?? 'main';
 
     project.github?.tryFindWorkflow('build')?.on({
       mergeGroup: {

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -2630,7 +2630,7 @@ on:
   workflow_dispatch: {}
   merge_group:
     branches:
-      - main
+      - banana
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -2911,7 +2911,7 @@ on:
       - edited
   merge_group:
     branches:
-      - main
+      - banana
 jobs:
   validate:
     name: Validate PR title

--- a/test/cdklabs.test.ts
+++ b/test/cdklabs.test.ts
@@ -368,6 +368,9 @@ class TestCdklabsJsiiProject extends CdklabsJsiiProject {
       defaultReleaseBranch: 'main',
       author: 'AWS',
       authorAddress: 'aws-cdk-dev@amazon.com',
+      ghAutoMergeOptions: {
+        mergeBranch: 'banana',
+      },
       ...options,
     });
   }


### PR DESCRIPTION
Some repositories have a different branch to auto-merge into than "main". Allow users to configure a different one by passing the `mergeBranch` property.