### PR TITLE
feat: expose new projen features

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,4 @@ The location the workspace is placed at. Defaults to `./packages`
 
 - `excludeDepsFromUpgrade: Array<string>`\
 List any dependencies that should not be updated in the workspace.
+


### PR DESCRIPTION
The new projen release adds features to control the version bump feature. These features are automatically published via `cdklabs-projen-project-types` as well.

Fixes #