### PR TITLE
feat: monorepo support passing on `nextVersionCommand`

### DIFF
--- a/API.md
+++ b/API.md
@@ -37419,6 +37419,7 @@ const workspaceReleaseOptions: yarn.WorkspaceReleaseOptions = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.private">private</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.nextVersionCommand">nextVersionCommand</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.publishToNpm">publishToNpm</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.releasableCommits">releasableCommits</a></code> | <code>projen.ReleasableCommits</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.workflowNodeVersion">workflowNodeVersion</a></code> | <code>string</code> | *No description.* |
@@ -37432,6 +37433,16 @@ public readonly private: boolean;
 ```
 
 - *Type:* boolean
+
+---
+
+##### `nextVersionCommand`<sup>Optional</sup> <a name="nextVersionCommand" id="cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.nextVersionCommand"></a>
+
+```typescript
+public readonly nextVersionCommand: string;
+```
+
+- *Type:* string
 
 ---
 

--- a/src/yarn/typescript-workspace-release.ts
+++ b/src/yarn/typescript-workspace-release.ts
@@ -10,6 +10,7 @@ export interface WorkspaceReleaseOptions {
   readonly workflowNodeVersion?: string;
   readonly publishToNpm?: boolean;
   readonly releasableCommits?: ReleasableCommits;
+  readonly nextVersionCommand?: string;
 }
 
 export class WorkspaceRelease extends Component {
@@ -39,6 +40,8 @@ export class WorkspaceRelease extends Component {
         // In a monorepo, only consider changes relevant to the subproject
         // Path is relative to the subproject outdir, so '.' is what we want here
         releasableCommits: options.releasableCommits ?? ReleasableCommits.everyCommit('.'),
+
+        nextVersionCommand: options.nextVersionCommand,
       });
 
       this.publisher = new release.Publisher(this.workspace, {


### PR DESCRIPTION
This value needed to be manually copied.
