### PR TITLE
fix: bundled dependencies should lead to a Yarn nohoist directive

### DIFF
--- a/API.md
+++ b/API.md
@@ -13477,6 +13477,7 @@ When given a project, this it the project itself.
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.property.eslint">eslint</a></code> | <code>projen.javascript.Eslint</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.property.tsconfig">tsconfig</a></code> | <code>projen.javascript.TypescriptConfig</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.property.tsconfigEslint">tsconfigEslint</a></code> | <code>projen.javascript.TypescriptConfig</code> | *No description.* |
+| <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.property.workspaceDirectory">workspaceDirectory</a></code> | <code>string</code> | *No description.* |
 
 ---
@@ -14228,6 +14229,16 @@ public readonly tsconfigEslint: TypescriptConfig;
 ```
 
 - *Type:* projen.javascript.TypescriptConfig
+
+---
+
+##### `bundledDeps`<sup>Required</sup> <a name="bundledDeps" id="cdklabs-projen-project-types.yarn.TypeScriptWorkspace.property.bundledDeps"></a>
+
+```typescript
+public readonly bundledDeps: string[];
+```
+
+- *Type:* string[]
 
 ---
 

--- a/src/yarn/monorepo.ts
+++ b/src/yarn/monorepo.ts
@@ -167,6 +167,7 @@ export class Monorepo extends typescript.TypeScriptProject {
     this.package.addField('private', true);
     this.package.addField('workspaces', {
       packages: this.projects.map((p) => p.workspaceDirectory),
+      ...this.renderNoHoist(),
     });
 
     this.tsconfig?.file.addOverride('include', []);
@@ -181,6 +182,21 @@ export class Monorepo extends typescript.TypeScriptProject {
     this.package.addField('jest', {
       projects: this.projects.map((p) => `<rootDir>/${p.workspaceDirectory}`),
     });
+  }
+
+  /**
+   * Render the 'nohoist' directive
+   *
+   * Bundled dependencies must be nohoist'ed, otherwise NPM silently won't bundle them.
+   *
+   * Renders an object that should be mixed into the `workspaces` object.
+   */
+  private renderNoHoist(): any {
+    const nohoist = this.projects.flatMap(p => p.bundledDeps.flatMap(dep => [
+      `${p.name}/${dep}`,
+      `${p.name}/${dep}/**`,
+    ]));
+    return nohoist.length > 0 ? { nohoist } : undefined;
   }
 
   /**

--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -9,6 +9,7 @@ import { TypeScriptWorkspaceOptions } from './typescript-workspace-options';
  */
 export class TypeScriptWorkspace extends typescript.TypeScriptProject {
   public readonly workspaceDirectory: string;
+  public readonly bundledDeps: string[] = [];
 
   private readonly monorepo: Monorepo;
   private readonly isPrivatePackage: boolean;
@@ -188,6 +189,8 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject {
     // Fixes
     this.addTsconfigDevFix();
     this.addEslintRcFix();
+
+    this.bundledDeps.push(...options.bundledDeps ?? []);
 
     options.parent.register(this);
   }

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -24,6 +24,33 @@ describe('CdkLabsMonorepo', () => {
     expect(outdir).toMatchSnapshot();
   });
 
+  test('bundled dependencies lead to a nohoist directive', () => {
+    // GIVEN
+    const parent = new yarn.CdkLabsMonorepo({
+      name: 'monorepo',
+      defaultReleaseBranch: 'main',
+    });
+
+    new yarn.TypeScriptWorkspace({
+      parent,
+      name: '@cdklabs/one',
+      // WHEN
+      bundledDeps: ['jsonschema'],
+    });
+
+    // THEN
+    const outdir = Testing.synth(parent);
+
+    expect(outdir['package.json']).toEqual(expect.objectContaining({
+      workspaces: expect.objectContaining({
+        nohoist: [
+          '@cdklabs/one/jsonschema',
+          '@cdklabs/one/jsonschema/**',
+        ],
+      })
+    }));
+  });
+
   test('workspaces get monorepo repository configuration', () => {
     const testRepository = 'https://github.com/cdklabs/cdklabs-projen-project-types';
     const parent = new yarn.CdkLabsMonorepo({

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -47,7 +47,7 @@ describe('CdkLabsMonorepo', () => {
           '@cdklabs/one/jsonschema',
           '@cdklabs/one/jsonschema/**',
         ],
-      })
+      }),
     }));
   });
 


### PR DESCRIPTION
Without this directive, the dependency will be hoisted to a top-level `node_modules` directory, but if it's there NPM will not bundle it when running `npm pack`.
