### PR TITLE
fix(cdk-cli-integ): publish only specific packages

### DIFF
--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -255,7 +255,11 @@ export class CdkCliIntegTestsWorkflow extends Component {
         },
         {
           name: 'Find an locally publish all tarballs',
-          run: 'find packages -name \\*.tgz -print0 | xargs -0 -n1 npm publish',
+          run: [
+            `for pkg in packages/{${props.localPackages.join(',')}}/dist/js/*.tgz; do`,
+            '  npm publish $pkg',
+            'done',
+          ].join('\n'),
         },
         {
           name: 'Download and install the test artifact',

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -146,7 +146,7 @@ jobs:
       - name: Create Verdaccio config
         run: |-
           mkdir -p $HOME/.config/verdaccio
-          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/bla":{"access":"$all","publish":"$all","proxy":"none"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
+          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/bla":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/bloeh":{"access":"$all","publish":"$all","proxy":"none"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
       - name: Start Verdaccio
         run: |-
           pm2 start verdaccio -- --config $HOME/.config/verdaccio/config.yaml
@@ -156,7 +156,10 @@ jobs:
           echo '//localhost:4873/:_authToken="MWRjNDU3OTE1NTljYWUyOTFkMWJkOGUyYTIwZWMwNTI6YTgwZjkyNDE0NzgwYWQzNQ=="' > ~/.npmrc
           echo 'registry=http://localhost:4873/' >> ~/.npmrc
       - name: Find an locally publish all tarballs
-        run: find packages -name \\*.tgz -print0 | xargs -0 -n1 npm publish
+        run: |-
+          for pkg in packages/{@aws-cdk/bla,@aws-cdk/bloeh}/dist/js/*.tgz; do
+            npm publish $pkg
+          done
       - name: Download and install the test artifact
         run: |-
           npm install @aws-cdk-testing/cli-integ

--- a/test/cdk-cli-integ-tests.test.ts
+++ b/test/cdk-cli-integ-tests.test.ts
@@ -12,7 +12,7 @@ test('snapshot test for the CDK CLI integ tests', () => {
     testEnvironment: 'test',
     buildRunsOn: 'runsOn',
     testRunsOn: 'testRunsOn',
-    localPackages: ['@aws-cdk/bla'],
+    localPackages: ['@aws-cdk/bla', '@aws-cdk/bloeh'],
   });
 
   const outdir = Testing.synth(repo);


### PR DESCRIPTION
We used to publish *all* `tgz` files, but only accepted select packages into the Verdaccio registry. That meant all non-accepted packages were proxied, and we would try to publish those to upstream npmjs.com which would fail.

In this change, publish exactly those tarballs that we accept into Verdaccio and no others.
