### PR TITLE
fix(cli-test-workflow): flip the flag indicating the version of cli-lib-alpha

### DIFF
--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -95,6 +95,9 @@ export class CdkCliIntegTestsWorkflow extends Component {
       },
       env: {
         CI: 'true',
+        // This is necessary because the new versioning of @aws-cdk/cli-lib-alpha
+        // matches the CLI and not the framework.
+        CLI_LIB_VERSION_MIRRORS_CLI: 'true',
       },
       steps: [
         {

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -85,6 +85,7 @@ jobs:
     environment: approval
     env:
       CI: "true"
+      CLI_LIB_VERSION_MIRRORS_CLI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This flag is necessary to indicate the new versioning.