### PR TITLE
fix(cli-test-workflow): add bump command and set env vars

### DIFF
--- a/API.md
+++ b/API.md
@@ -14691,6 +14691,7 @@ const cdkCliIntegTestsWorkflowProps: CdkCliIntegTestsWorkflowProps = { ... }
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.localPackages">localPackages</a></code> | <code>string[]</code> | Packages that are locally transfered (we will never use the upstream versions). |
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.testEnvironment">testEnvironment</a></code> | <code>string</code> | GitHub environment name for running the tests. |
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.testRunsOn">testRunsOn</a></code> | <code>string</code> | Runners for the workflow. |
+| <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.expectNewCliLibVersion">expectNewCliLibVersion</a></code> | <code>boolean</code> | Whether or not we expect the new cli-lib version. |
 
 ---
 
@@ -14759,6 +14760,24 @@ public readonly testRunsOn: string;
 - *Type:* string
 
 Runners for the workflow.
+
+---
+
+##### `expectNewCliLibVersion`<sup>Optional</sup> <a name="expectNewCliLibVersion" id="cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.expectNewCliLibVersion"></a>
+
+```typescript
+public readonly expectNewCliLibVersion: boolean;
+```
+
+- *Type:* boolean
+
+Whether or not we expect the new cli-lib version.
+
+This needs to be `false` for a while in the `aws-cdk-cli-testing`
+package, until we have had a release of `aws-cdk-cli` with the new
+version.
+
+This needs to be `true` always for the `aws-cdk-cli` repo.
 
 ---
 

--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -95,9 +95,6 @@ export class CdkCliIntegTestsWorkflow extends Component {
       },
       env: {
         CI: 'true',
-        // This is necessary because the new versioning of @aws-cdk/cli-lib-alpha
-        // matches the CLI and not the framework.
-        CLI_LIB_VERSION_MIRRORS_CLI: 'true',
       },
       steps: [
         {
@@ -120,6 +117,13 @@ export class CdkCliIntegTestsWorkflow extends Component {
         {
           name: 'Install dependencies',
           run: 'yarn install --check-files',
+        },
+        {
+          name: 'Bump to realistic versions',
+          run: 'yarn workspaces run bump',
+          env: {
+            TESTING_CANDIDATE: 'true',
+          },
         },
         {
           name: 'build',
@@ -171,6 +175,9 @@ export class CdkCliIntegTestsWorkflow extends Component {
         // assumptions about the availability of source packages.
         IS_CANARY: 'true',
         CI: 'true',
+        // This is necessary because the new versioning of @aws-cdk/cli-lib-alpha
+        // matches the CLI and not the framework.
+        CLI_LIB_VERSION_MIRRORS_CLI: 'true',
       },
       strategy: {
         failFast: false,

--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -33,6 +33,17 @@ export interface CdkCliIntegTestsWorkflowProps {
    * Packages that are locally transfered (we will never use the upstream versions)
    */
   readonly localPackages: string[];
+
+  /**
+   * Whether or not we expect the new cli-lib version
+   *
+   * This needs to be `false` for a while in the `aws-cdk-cli-testing`
+   * package, until we have had a release of `aws-cdk-cli` with the new
+   * version.
+   *
+   * This needs to be `true` always for the `aws-cdk-cli` repo.
+   */
+  readonly expectNewCliLibVersion?: boolean;
 }
 
 /**
@@ -184,7 +195,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
         CI: 'true',
         // This is necessary because the new versioning of @aws-cdk/cli-lib-alpha
         // matches the CLI and not the framework.
-        CLI_LIB_VERSION_MIRRORS_CLI: 'true',
+        ...props.expectNewCliLibVersion ? { CLI_LIB_VERSION_MIRRORS_CLI: 'true' } : {},
       },
       strategy: {
         failFast: false,

--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -103,10 +103,10 @@ export class CdkCliIntegTestsWorkflow extends Component {
           with: {
             // IMPORTANT! This must be `head.sha` not `head.ref`, otherwise we
             // are vulnerable to a TOCTOU attack.
-            ref: '${{ github.event.pull_request.head.sha }}',
-            repository: '${{ github.event.pull_request.head.repo.full_name }}',
+            'ref': '${{ github.event.pull_request.head.sha }}',
+            'repository': '${{ github.event.pull_request.head.repo.full_name }}',
             // This is necessary to fetch tags, otherwise bumping won't work properly.
-            'fetch-depth': 0
+            'fetch-depth': 0,
           },
         },
         {

--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -105,6 +105,8 @@ export class CdkCliIntegTestsWorkflow extends Component {
             // are vulnerable to a TOCTOU attack.
             ref: '${{ github.event.pull_request.head.sha }}',
             repository: '${{ github.event.pull_request.head.repo.full_name }}',
+            // This is necessary to fetch tags, otherwise bumping won't work properly.
+            'fetch-depth': 0
           },
         },
         {
@@ -128,6 +130,11 @@ export class CdkCliIntegTestsWorkflow extends Component {
         {
           name: 'build',
           run: 'npx projen build',
+          env: {
+            // This is necessary to prevent projen from resetting the version numbers to
+            // 0.0.0 during its synthesis.
+            RELEASE: 'true',
+          },
         },
         {
           name: 'Upload artifact',

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -85,7 +85,6 @@ jobs:
     environment: approval
     env:
       CI: "true"
-      CLI_LIB_VERSION_MIRRORS_CLI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -98,6 +97,10 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
+      - name: Bump to realistic versions
+        env:
+          TESTING_CANDIDATE: "true"
+        run: yarn workspaces run bump
       - name: build
         run: npx projen build
       - name: Upload artifact
@@ -117,6 +120,7 @@ jobs:
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"
       CI: "true"
+      CLI_LIB_VERSION_MIRRORS_CLI: "true"
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -123,7 +123,6 @@ jobs:
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"
       CI: "true"
-      CLI_LIB_VERSION_MIRRORS_CLI: "true"
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -91,6 +91,7 @@ jobs:
         with:
           ref: \${{ github.event.pull_request.head.sha }}
           repository: \${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -102,6 +103,8 @@ jobs:
           TESTING_CANDIDATE: "true"
         run: yarn workspaces run bump
       - name: build
+        env:
+          RELEASE: "true"
         run: npx projen build
       - name: Upload artifact
         uses: actions/upload-artifact@v4.4.0


### PR DESCRIPTION
In https://github.com/cdklabs/cdklabs-projen-project-types/pull/780 I was a bit too hasty; the environment variable needed to be on the `integ` job instead of the `build` job, and I forgot to add a `bump` step.

Also, we need to set `$RELEASE=true` on the build, otherwise projen synthesis will reset all version numbers.

We also need to make sure to fetch all tags on checkout, otherwise the version bumping will not work.

Fix those issues in this PR.