### PR TITLE
fix(cli-test-workflow): trigger on merge queues but don't do the run

### DIFF
--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -87,6 +87,10 @@ export class CdkCliIntegTestsWorkflow extends Component {
       pullRequestTarget: {
         branches: ['main'],
       },
+      // Needs to trigger and report success on merge queue builds as well
+      mergeGroup: {},
+      // Never hurts to be able to run this manually
+      workflowDispatch: {},
     });
     // The 'build' part runs on the 'integ-approval' environment, which requires
     // approval. The actual runs access the real environment, not requiring approval
@@ -107,6 +111,9 @@ export class CdkCliIntegTestsWorkflow extends Component {
       env: {
         CI: 'true',
       },
+      // Don't run again on the merge queue, we already got confirmation that it works and the
+      // tests are quite expensive.
+      if: "github.event_name != 'merge_group'",
       steps: [
         {
           name: 'Checkout',
@@ -200,6 +207,9 @@ export class CdkCliIntegTestsWorkflow extends Component {
         // matches the CLI and not the framework.
         ...props.expectNewCliLibVersion ? { CLI_LIB_VERSION_MIRRORS_CLI: 'true' } : {},
       },
+      // Don't run again on the merge queue, we already got confirmation that it works and the
+      // tests are quite expensive.
+      if: "github.event_name != 'merge_group'",
       strategy: {
         failFast: false,
         matrix: {

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -158,6 +158,8 @@ on:
   pull_request_target:
     branches:
       - main
+  merge_group: {}
+  workflow_dispatch: {}
 jobs:
   prepare:
     runs-on: runsOn
@@ -166,6 +168,7 @@ jobs:
     environment: approval
     env:
       CI: "true"
+    if: github.event_name != 'merge_group'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -204,6 +207,7 @@ jobs:
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"
       CI: "true"
+    if: github.event_name != 'merge_group'
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
We use merge queues: if the tests are required they need to report success so they need to trigger. Don't actually do the tests again though, they take forever and we already ran them.
