### PR TITLE
fix(cli-integ-tests): integ tests not triggered on merge queue

### DIFF
--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -87,6 +87,10 @@ export class CdkCliIntegTestsWorkflow extends Component {
       pullRequestTarget: {
         branches: ['main'],
       },
+      // we need to trigger the workflow on the merge group so we can make it a required status check
+      // but we don't actually want to run the integ-test on the merge queue,
+      // so we later add an if condition to the job to always pass it when run on the merge queue
+      mergeGroup: {},
     });
     // The 'build' part runs on the 'integ-approval' environment, which requires
     // approval. The actual runs access the real environment, not requiring approval
@@ -99,6 +103,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
     //   If the matrix test job needs approval, the Pull Request timeline gets spammed
     //   with an approval request for every individual run.
     runTestsWorkflow.addJob('prepare', {
+      if: "if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')",
       environment: props.approvalEnvironment,
       runsOn: [props.buildRunsOn],
       permissions: {

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -158,6 +158,7 @@ on:
   pull_request_target:
     branches:
       - main
+  merge_group: {}
 jobs:
   prepare:
     runs-on: runsOn
@@ -166,6 +167,7 @@ jobs:
     environment: approval
     env:
       CI: "true"
+    if: "if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds the required workflow trigger to start the workflow on the merge queue.
But we don't actually want to run the tests on the merge queue, so we just skip them. 