### PR TITLE
fix(monorepo): make release internal accessible

### DIFF
--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -20,6 +20,8 @@ export class MonorepoRelease extends Component {
     return project.components.find(isMonorepoReleaseWorkflow);
   }
 
+  public readonly workspaceReleases = new Map<TypeScriptWorkspace, WorkspaceRelease>();
+
   private readonly branchName: string;
   private readonly github: github.GitHub;
   private readonly releaseTrigger: projenRelease.ReleaseTrigger;
@@ -51,6 +53,10 @@ export class MonorepoRelease extends Component {
       publishToNpm: this.options.publishToNpm,
       ...options,
     });
+
+    // Make these publicly accessible
+    this.workspaceReleases.set(project, workspaceRelease);
+
     if (!options.private && workspaceRelease.publisher) {
       this.obtainReleaseTask();
 

--- a/src/yarn/monorepo.ts
+++ b/src/yarn/monorepo.ts
@@ -5,10 +5,16 @@ import { MonorepoRelease } from './monorepo-release';
 import { Nx } from './nx';
 import { TypeScriptWorkspace } from './typescript-workspace';
 
+const MONOREPO_SYM = Symbol.for('cdklabs-projen-project-types.yarn.Monorepo');
+
 /**
  * A monorepo using yarn workspaces.
  */
 export class Monorepo extends typescript.TypeScriptProject {
+  public static isMonorepo(x: Project): x is Monorepo {
+    return Boolean(x && typeof x === 'object' && MONOREPO_SYM in x);
+  }
+
   public readonly monorepoRelease?: MonorepoRelease;
 
   /**
@@ -28,6 +34,8 @@ export class Monorepo extends typescript.TypeScriptProject {
       eslint: false,
       release: false,
     });
+
+    Object.defineProperty(this, MONOREPO_SYM, { value: true });
 
     this.repositoryUrl = options.repository;
 


### PR DESCRIPTION
This is necessary to enable jsii builds in a monorepo.
