### PR TITLE
fix(monorepo): npmDistTag is not working

### DIFF
--- a/API.md
+++ b/API.md
@@ -38013,6 +38013,7 @@ const workspaceReleaseOptions: yarn.WorkspaceReleaseOptions = { ... }
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.private">private</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.versionBranchOptions">versionBranchOptions</a></code> | <code>projen.VersionBranchOptions</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.nextVersionCommand">nextVersionCommand</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.npmDistTag">npmDistTag</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.publishToNpm">publishToNpm</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.releasableCommits">releasableCommits</a></code> | <code>projen.ReleasableCommits</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.workflowNodeVersion">workflowNodeVersion</a></code> | <code>string</code> | *No description.* |
@@ -38043,6 +38044,16 @@ public readonly versionBranchOptions: VersionBranchOptions;
 
 ```typescript
 public readonly nextVersionCommand: string;
+```
+
+- *Type:* string
+
+---
+
+##### `npmDistTag`<sup>Optional</sup> <a name="npmDistTag" id="cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.npmDistTag"></a>
+
+```typescript
+public readonly npmDistTag: string;
 ```
 
 - *Type:* string

--- a/src/yarn/typescript-workspace-release.ts
+++ b/src/yarn/typescript-workspace-release.ts
@@ -9,6 +9,7 @@ export interface WorkspaceReleaseOptions {
   /** @default 'lts/*' */
   readonly workflowNodeVersion?: string;
   readonly publishToNpm?: boolean;
+  readonly npmDistTag?: string;
   readonly releasableCommits?: ReleasableCommits;
   readonly nextVersionCommand?: string;
   readonly versionBranchOptions: VersionBranchOptions;
@@ -61,6 +62,7 @@ export class WorkspaceRelease extends Component {
       // GitHub Releases comes for free with a `Release` component, NPM must be added explicitly
       if (options.publishToNpm ?? true) {
         this.publisher.publishToNpm({
+          distTag: options.npmDistTag,
           registry: project.package.npmRegistry,
           npmTokenSecret: project.package.npmTokenSecret,
         });

--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -110,6 +110,7 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject {
     this.monorepo.monorepoRelease?.addWorkspace(this, {
       private: this.isPrivatePackage,
       workflowNodeVersion: this.nodeVersion,
+      npmDistTag: options.npmDistTag,
       releasableCommits: options.releasableCommits,
       nextVersionCommand: options.nextVersionCommand,
       versionBranchOptions: {

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -150,6 +150,24 @@ describe('CdkLabsMonorepo', () => {
         MIN_MAJOR: '3',
       }));
     });
+
+    test('npmDistTag works', () => {
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/one',
+        npmDistTag: 'foobar',
+      });
+
+      Testing.synth(parent);
+
+      expect(parent.github?.tryFindWorkflow('release')?.getJob('cdklabs-one_release_npm'))
+        .toMatchObject(expect.objectContaining({
+          steps: expect.arrayContaining([expect.objectContaining({
+            name: 'Release',
+            env: expect.objectContaining({ NPM_DIST_TAG: 'foobar' }),
+          })]),
+        }));
+    });
   });
 
   describe('VSCode Workspace', () => {


### PR DESCRIPTION
Fixes `npmDistTag` being ignored in a monorepo.