### PR TITLE
fix(monorepo): warning "The `distTag` option is deprecated. Use the npmDistTag option instead."

### DIFF
--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -28,6 +28,7 @@ export class MonorepoRelease extends Component {
     readonly release: {
       readonly workspace: TypeScriptWorkspace;
       readonly publisher: projenRelease.Publisher;
+      readonly options: Partial<projenRelease.BranchOptions>;
     };
   }>();
 
@@ -72,6 +73,17 @@ export class MonorepoRelease extends Component {
         release: {
           workspace: workspaceRelease.workspace,
           publisher: workspaceRelease.publisher,
+          options: {
+            // enforced options
+            workflowName: this.options.releaseWorkflowName,
+            tagPrefix: `${project.name}@`,
+
+            // options that may be override locally
+            majorVersion: options.versionBranchOptions.majorVersion ?? this.options.majorVersion,
+            minMajorVersion: options.versionBranchOptions.minMajorVersion ?? this.options.minMajorVersion,
+            prerelease: options.versionBranchOptions.prerelease ?? this.options.prerelease,
+            npmDistTag: options.npmDistTag ?? this.options.npmDistTag,
+          },
         },
       });
     }
@@ -116,12 +128,7 @@ export class MonorepoRelease extends Component {
 
   private renderPublishJobs() {
     for (const { release } of this.packagesToRelease) {
-      const packagePublishJobs = release.publisher._renderJobsForBranch(this.branchName, {
-        majorVersion: this.options.majorVersion,
-        minMajorVersion: this.options.minMajorVersion,
-        npmDistTag: this.options.npmDistTag,
-        prerelease: this.options.prerelease,
-      });
+      const packagePublishJobs = release.publisher._renderJobsForBranch(this.branchName, release.options);
 
       for (const job of Object.values(packagePublishJobs)) {
         // Find the 'download-artifact' job and replace the build artifact name with the unique per-project one

--- a/src/yarn/typescript-workspace-release.ts
+++ b/src/yarn/typescript-workspace-release.ts
@@ -62,7 +62,6 @@ export class WorkspaceRelease extends Component {
       // GitHub Releases comes for free with a `Release` component, NPM must be added explicitly
       if (options.publishToNpm ?? true) {
         this.publisher.publishToNpm({
-          distTag: options.npmDistTag,
           registry: project.package.npmRegistry,
           npmTokenSecret: project.package.npmTokenSecret,
         });

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -168,6 +168,37 @@ describe('CdkLabsMonorepo', () => {
           })]),
         }));
     });
+
+    test('prerelease is respected for the right workspace package', () => {
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/one',
+        prerelease: 'rc',
+      });
+
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/two',
+      });
+
+      Testing.synth(parent);
+
+      expect(parent.github?.tryFindWorkflow('release')?.getJob('cdklabs-one_release_github'))
+        .toMatchObject(expect.objectContaining({
+          steps: expect.arrayContaining([expect.objectContaining({
+            name: 'Release',
+            run: expect.stringContaining('-p'),
+          })]),
+        }));
+
+      expect(parent.github?.tryFindWorkflow('release')?.getJob('cdklabs-two_release_github'))
+        .toMatchObject(expect.objectContaining({
+          steps: expect.arrayContaining([expect.objectContaining({
+            name: 'Release',
+            run: expect.not.stringContaining('-p'),
+          })]),
+        }));
+    });
   });
 
   describe('VSCode Workspace', () => {


### PR DESCRIPTION
After implementing #795 our monorepo project started to get the warning:

```
👾 The `distTag` option is deprecated. Use the npmDistTag option instead.
```

While implementing the fix I noticed that some other options that a workspace package should be able to set are currently ignored. When calling `_renderJobsForBranch` for a workspace package, the global monorepo values would be used instead of the local project configuration.

In practice this has little impact beyond `npmDistTag`, since most of these options aren't actually used in any of the publisher jobs. The only other use is the `prerelease` option, which tells the GitHub release job to mark a release as prerelease (or not). You could observe the wrong behavior on a current `cdk-assets` [release](https://github.com/aws/aws-cdk-cli/releases/tag/cdk-assets%40v3.0.0-rc.144) from `aws/aws-cdk-cli` (note that by the time you are reading this the linked release probably has been manually updated to be a pre-release).


