### PR TITLE
fix(monorepo): npm provenance is not respected

### DIFF
--- a/src/yarn/typescript-workspace-release.ts
+++ b/src/yarn/typescript-workspace-release.ts
@@ -64,6 +64,7 @@ export class WorkspaceRelease extends Component {
         this.publisher.publishToNpm({
           registry: project.package.npmRegistry,
           npmTokenSecret: project.package.npmTokenSecret,
+          npmProvenance: project.package.npmProvenance,
         });
       }
     }

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -2840,6 +2840,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
     if: \${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-cdklabs-one == 'true' }}
     steps:
@@ -2858,6 +2859,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
   cdklabs-two_release_github:
@@ -2892,6 +2894,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
     if: \${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-cdklabs-two == 'true' }}
     steps:
@@ -2910,6 +2913,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
 ",

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -199,6 +199,25 @@ describe('CdkLabsMonorepo', () => {
           })]),
         }));
     });
+
+    test('will automatically enable npm release provenance', () => {
+      const one = new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/one',
+        npmDistTag: 'foobar',
+      });
+
+      Testing.synth(parent);
+
+      expect(one.package.npmProvenance).toBe(true);
+      expect(parent.github?.tryFindWorkflow('release')?.getJob('cdklabs-one_release_npm'))
+        .toMatchObject(expect.objectContaining({
+          steps: expect.arrayContaining([expect.objectContaining({
+            name: 'Release',
+            env: expect.objectContaining({ NPM_CONFIG_PROVENANCE: 'true' }),
+          })]),
+        }));
+    });
   });
 
   describe('VSCode Workspace', () => {


### PR DESCRIPTION
Previously monorepo packages were released without provenance statements.