### PR TITLE
feat(cli-integ-tests): allow skipping integ tests with label

### DIFF
--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -361,7 +361,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
       permissions: {},
       runsOn: [props.testRunsOn],
       needs: [JOB_INTEG_MATRIX],
-      if: `always() && ${NOT_FLAGGED_EXPR}`,
+      if: 'always()',
       steps: [
         {
           name: 'Integ test result',

--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -1,5 +1,7 @@
 import { Component, github, javascript } from 'projen';
 
+const NOT_FLAGGED_EXPR = "!contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')";
+
 export interface CdkCliIntegTestsWorkflowProps {
   /**
    * Runners for the workflow
@@ -113,7 +115,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
       },
       // Don't run again on the merge queue, we already got confirmation that it works and the
       // tests are quite expensive.
-      if: "github.event_name != 'merge_group'",
+      if: `github.event_name != 'merge_group' && ${NOT_FLAGGED_EXPR}`,
       steps: [
         {
           name: 'Checkout',
@@ -215,7 +217,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
       },
       // Don't run again on the merge queue, we already got confirmation that it works and the
       // tests are quite expensive.
-      if: "github.event_name != 'merge_group'",
+      if: `github.event_name != 'merge_group' && ${NOT_FLAGGED_EXPR}`,
       strategy: {
         failFast: false,
         matrix: {
@@ -359,7 +361,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
       permissions: {},
       runsOn: [props.testRunsOn],
       needs: [JOB_INTEG_MATRIX],
-      if: 'always()',
+      if: `always() && ${NOT_FLAGGED_EXPR}`,
       steps: [
         {
           name: 'Integ test result',

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -168,7 +168,7 @@ jobs:
     environment: approval
     env:
       CI: "true"
-    if: github.event_name != 'merge_group'
+    if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -207,7 +207,7 @@ jobs:
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"
       CI: "true"
-    if: github.event_name != 'merge_group'
+    if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -295,7 +295,7 @@ jobs:
     needs: integ_matrix
     runs-on: testRunsOn
     permissions: {}
-    if: always()
+    if: always() && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
       - name: Integ test result
         run: echo \${{ needs.integ_matrix.result }}

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -295,7 +295,7 @@ jobs:
     needs: integ_matrix
     runs-on: testRunsOn
     permissions: {}
-    if: always() && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
+    if: always()
     steps:
       - name: Integ test result
         run: echo \${{ needs.integ_matrix.result }}


### PR DESCRIPTION
Allows skipping the integ workflow if the label `pr/exempt-integ-test` is added.
