### PR TITLE
fix(cli-integ-tests)!: fetch tags from upstream

### DIFF
--- a/API.md
+++ b/API.md
@@ -14732,9 +14732,9 @@ const cdkCliIntegTestsWorkflowProps: CdkCliIntegTestsWorkflowProps = { ... }
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.approvalEnvironment">approvalEnvironment</a></code> | <code>string</code> | GitHub environment name for approvals. |
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.buildRunsOn">buildRunsOn</a></code> | <code>string</code> | Runners for the workflow. |
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.localPackages">localPackages</a></code> | <code>string[]</code> | Packages that are locally transfered (we will never use the upstream versions). |
+| <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.sourceRepo">sourceRepo</a></code> | <code>string</code> | The official repo this workflow is used for. |
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.testEnvironment">testEnvironment</a></code> | <code>string</code> | GitHub environment name for running the tests. |
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.testRunsOn">testRunsOn</a></code> | <code>string</code> | Runners for the workflow. |
-| <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.expectNewCliLibVersion">expectNewCliLibVersion</a></code> | <code>boolean</code> | Whether or not we expect the new cli-lib version. |
 
 ---
 
@@ -14776,6 +14776,18 @@ Packages that are locally transfered (we will never use the upstream versions).
 
 ---
 
+##### `sourceRepo`<sup>Required</sup> <a name="sourceRepo" id="cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.sourceRepo"></a>
+
+```typescript
+public readonly sourceRepo: string;
+```
+
+- *Type:* string
+
+The official repo this workflow is used for.
+
+---
+
 ##### `testEnvironment`<sup>Required</sup> <a name="testEnvironment" id="cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.testEnvironment"></a>
 
 ```typescript
@@ -14803,24 +14815,6 @@ public readonly testRunsOn: string;
 - *Type:* string
 
 Runners for the workflow.
-
----
-
-##### `expectNewCliLibVersion`<sup>Optional</sup> <a name="expectNewCliLibVersion" id="cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.expectNewCliLibVersion"></a>
-
-```typescript
-public readonly expectNewCliLibVersion: boolean;
-```
-
-- *Type:* boolean
-
-Whether or not we expect the new cli-lib version.
-
-This needs to be `false` for a while in the `aws-cdk-cli-testing`
-package, until we have had a release of `aws-cdk-cli` with the new
-version.
-
-This needs to be `true` always for the `aws-cdk-cli` repo.
 
 ---
 

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -176,6 +176,10 @@ jobs:
           ref: \${{ github.event.pull_request.head.sha }}
           repository: \${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
+      - name: Fetch tags from origin repo
+        run: |-
+          git remote add upstream git@github.com:aws/some-repo.git
+          git fetch upstream 'refs/tags/*:refs/tags/*'
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -207,6 +211,7 @@ jobs:
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"
       CI: "true"
+      CLI_LIB_VERSION_MIRRORS_CLI: "true"
     if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
       - name: Download build artifacts

--- a/test/cdk-cli-integ-tests.test.ts
+++ b/test/cdk-cli-integ-tests.test.ts
@@ -13,6 +13,7 @@ test('snapshot test for the CDK CLI integ tests', () => {
     buildRunsOn: 'runsOn',
     testRunsOn: 'testRunsOn',
     localPackages: ['@aws-cdk/bla', '@aws-cdk/bloeh'],
+    sourceRepo: 'aws/some-repo',
   });
 
   const outdir = Testing.synth(repo);


### PR DESCRIPTION
When the CLI integ tests run from a fork, the fork won't have the version tags and the candidate bumping fails (everything gets bumped to `0.0.0`, which causes tests to fail).

Instead, fetch tags from upstream.

I've opted to make the repo to fetch from an explicit parameter; I could have guessed that the repo would be `aws/<fork-name>`, but that just seemed like another avenue to get subtle bugs in the future.

Since this is now a newly required parameter which is breaking, I might as well remove the parameter that was only temporarily there for the duration of the migration.
