### PR TITLE
fix(cli-integ-tests): fetch tags from another URL

### DIFF
--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -117,8 +117,8 @@ export class CdkCliIntegTestsWorkflow extends Component {
           with: {
             // IMPORTANT! This must be `head.sha` not `head.ref`, otherwise we
             // are vulnerable to a TOCTOU attack.
-            'ref': '${{ github.event.pull_request.head.sha }}',
-            'repository': '${{ github.event.pull_request.head.repo.full_name }}',
+            ref: '${{ github.event.pull_request.head.sha }}',
+            repository: '${{ github.event.pull_request.head.repo.full_name }}',
           },
         },
         // We used to fetch tags from the repo using 'checkout', but if it's a fork

--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -119,8 +119,6 @@ export class CdkCliIntegTestsWorkflow extends Component {
             // are vulnerable to a TOCTOU attack.
             'ref': '${{ github.event.pull_request.head.sha }}',
             'repository': '${{ github.event.pull_request.head.repo.full_name }}',
-            // This is necessary to fetch tags, otherwise bumping won't work properly.
-            'fetch-depth': 0,
           },
         },
         // We used to fetch tags from the repo using 'checkout', but if it's a fork
@@ -131,7 +129,8 @@ export class CdkCliIntegTestsWorkflow extends Component {
           name: 'Fetch tags from origin repo',
           run: [
             // Can be either aws/aws-cdk-cli or aws/aws-cdk-cli-testing
-            `git remote add upstream git@github.com:${props.sourceRepo}.git`,
+            // (Has to be exactly this form because we're unauthenticated)
+            `git remote add upstream git://github.com/${props.sourceRepo}`,
             'git fetch upstream \'refs/tags/*:refs/tags/*\'',
           ].join('\n'),
         },

--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -129,8 +129,8 @@ export class CdkCliIntegTestsWorkflow extends Component {
           name: 'Fetch tags from origin repo',
           run: [
             // Can be either aws/aws-cdk-cli or aws/aws-cdk-cli-testing
-            // (Has to be exactly this form because we're unauthenticated)
-            `git remote add upstream git://github.com/${props.sourceRepo}`,
+            // (Must clone over HTTPS because we have no SSH auth set up)
+            `git remote add upstream https://github.com/${props.sourceRepo}.git`,
             'git fetch upstream \'refs/tags/*:refs/tags/*\'',
           ].join('\n'),
         },

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -175,10 +175,9 @@ jobs:
         with:
           ref: \${{ github.event.pull_request.head.sha }}
           repository: \${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0
       - name: Fetch tags from origin repo
         run: |-
-          git remote add upstream git@github.com:aws/some-repo.git
+          git remote add upstream https://github.com/aws/some-repo.git
           git fetch upstream 'refs/tags/*:refs/tags/*'
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
We have to fetch over HTTPS because the workflow has no ssh auth set up.

Also reset fetch depth to only fetch 1 commit.
