### PR TITLE
feat(cli-integ-test): allow configuring upstream versions

### DIFF
--- a/API.md
+++ b/API.md
@@ -14735,6 +14735,7 @@ const cdkCliIntegTestsWorkflowProps: CdkCliIntegTestsWorkflowProps = { ... }
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.sourceRepo">sourceRepo</a></code> | <code>string</code> | The official repo this workflow is used for. |
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.testEnvironment">testEnvironment</a></code> | <code>string</code> | GitHub environment name for running the tests. |
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.testRunsOn">testRunsOn</a></code> | <code>string</code> | Runners for the workflow. |
+| <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.allowUpstreamVersions">allowUpstreamVersions</a></code> | <code>string[]</code> | If given, allows accessing upstream versions of these packages. |
 
 ---
 
@@ -14773,6 +14774,8 @@ public readonly localPackages: string[];
 - *Type:* string[]
 
 Packages that are locally transfered (we will never use the upstream versions).
+
+Takes package names; these are expected to live in `packages/<NAME>/dist/js`.
 
 ---
 
@@ -14815,6 +14818,19 @@ public readonly testRunsOn: string;
 - *Type:* string
 
 Runners for the workflow.
+
+---
+
+##### `allowUpstreamVersions`<sup>Optional</sup> <a name="allowUpstreamVersions" id="cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.allowUpstreamVersions"></a>
+
+```typescript
+public readonly allowUpstreamVersions: string[];
+```
+
+- *Type:* string[]
+- *Default:* No upstream versions
+
+If given, allows accessing upstream versions of these packages.
 
 ---
 

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -242,7 +242,7 @@ jobs:
       - name: Create Verdaccio config
         run: |-
           mkdir -p $HOME/.config/verdaccio
-          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/bla":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/bloeh":{"access":"$all","publish":"$all","proxy":"none"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
+          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/bla":{"access":"$all","publish":"$all","proxy":"npmjs"},"@aws-cdk/bloeh":{"access":"$all","publish":"$all","proxy":"none"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
       - name: Start Verdaccio
         run: |-
           pm2 start verdaccio -- --config $HOME/.config/verdaccio/config.yaml

--- a/test/cdk-cli-integ-tests.test.ts
+++ b/test/cdk-cli-integ-tests.test.ts
@@ -14,6 +14,7 @@ test('snapshot test for the CDK CLI integ tests', () => {
     testRunsOn: 'testRunsOn',
     localPackages: ['@aws-cdk/bla', '@aws-cdk/bloeh'],
     sourceRepo: 'aws/some-repo',
+    allowUpstreamVersions: ['@aws-cdk/bla'],
   });
 
   const outdir = Testing.synth(repo);


### PR DESCRIPTION
Allows configuring that upstream versions are visible for select packages.

This will be used for `@aws-cdk/cloud-assembly-schema`, which we will need available under the new version (for `cdk-assets`) as well as under an old version (for `aws-cdk-lib`).
