### PR TITLE
fix: reduce dependency upgrade frequency to once a week

### DIFF
--- a/.github/workflows/upgrade-dev-deps-main.yml
+++ b/.github/workflows/upgrade-dev-deps-main.yml
@@ -4,7 +4,7 @@ name: upgrade-dev-deps-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 18 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade

--- a/API.md
+++ b/API.md
@@ -15022,8 +15022,6 @@ const cdkConstructLibraryOptions: CdkConstructLibraryOptions = { ... }
 | <code><a href="#cdklabs-projen-project-types.CdkConstructLibraryOptions.property.dependabot">dependabot</a></code> | <code>boolean</code> | Use dependabot to handle dependency upgrades. |
 | <code><a href="#cdklabs-projen-project-types.CdkConstructLibraryOptions.property.dependabotOptions">dependabotOptions</a></code> | <code>projen.github.DependabotOptions</code> | Options for dependabot. |
 | <code><a href="#cdklabs-projen-project-types.CdkConstructLibraryOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
-| <code><a href="#cdklabs-projen-project-types.CdkConstructLibraryOptions.property.depsUpgrade">depsUpgrade</a></code> | <code>boolean</code> | Use tasks and github workflows to handle dependency upgrades. |
-| <code><a href="#cdklabs-projen-project-types.CdkConstructLibraryOptions.property.depsUpgradeOptions">depsUpgradeOptions</a></code> | <code>projen.javascript.UpgradeDependenciesOptions</code> | Options for `UpgradeDependencies`. |
 | <code><a href="#cdklabs-projen-project-types.CdkConstructLibraryOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
 | <code><a href="#cdklabs-projen-project-types.CdkConstructLibraryOptions.property.devContainer">devContainer</a></code> | <code>boolean</code> | Add a VSCode development environment (used for GitHub Codespaces). |
 | <code><a href="#cdklabs-projen-project-types.CdkConstructLibraryOptions.property.devDeps">devDeps</a></code> | <code>string[]</code> | Build dependencies for this module. |
@@ -15868,34 +15866,6 @@ sense that it will add the module as a dependency to your `package.json`
 file with the latest version (`^`). You can specify semver requirements in
 the same syntax passed to `npm i` or `yarn add` (e.g. `express@^2`) and
 this will be what you `package.json` will eventually include.
-
----
-
-##### `depsUpgrade`<sup>Optional</sup> <a name="depsUpgrade" id="cdklabs-projen-project-types.CdkConstructLibraryOptions.property.depsUpgrade"></a>
-
-```typescript
-public readonly depsUpgrade: boolean;
-```
-
-- *Type:* boolean
-- *Default:* true
-
-Use tasks and github workflows to handle dependency upgrades.
-
-Cannot be used in conjunction with `dependabot`.
-
----
-
-##### `depsUpgradeOptions`<sup>Optional</sup> <a name="depsUpgradeOptions" id="cdklabs-projen-project-types.CdkConstructLibraryOptions.property.depsUpgradeOptions"></a>
-
-```typescript
-public readonly depsUpgradeOptions: UpgradeDependenciesOptions;
-```
-
-- *Type:* projen.javascript.UpgradeDependenciesOptions
-- *Default:* default options
-
-Options for `UpgradeDependencies`.
 
 ---
 
@@ -20505,8 +20475,6 @@ const cdklabsConstructLibraryOptions: CdklabsConstructLibraryOptions = { ... }
 | <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibraryOptions.property.dependabot">dependabot</a></code> | <code>boolean</code> | Use dependabot to handle dependency upgrades. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibraryOptions.property.dependabotOptions">dependabotOptions</a></code> | <code>projen.github.DependabotOptions</code> | Options for dependabot. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibraryOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
-| <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibraryOptions.property.depsUpgrade">depsUpgrade</a></code> | <code>boolean</code> | Use tasks and github workflows to handle dependency upgrades. |
-| <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibraryOptions.property.depsUpgradeOptions">depsUpgradeOptions</a></code> | <code>projen.javascript.UpgradeDependenciesOptions</code> | Options for `UpgradeDependencies`. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibraryOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibraryOptions.property.devContainer">devContainer</a></code> | <code>boolean</code> | Add a VSCode development environment (used for GitHub Codespaces). |
 | <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibraryOptions.property.devDeps">devDeps</a></code> | <code>string[]</code> | Build dependencies for this module. |
@@ -21353,34 +21321,6 @@ sense that it will add the module as a dependency to your `package.json`
 file with the latest version (`^`). You can specify semver requirements in
 the same syntax passed to `npm i` or `yarn add` (e.g. `express@^2`) and
 this will be what you `package.json` will eventually include.
-
----
-
-##### `depsUpgrade`<sup>Optional</sup> <a name="depsUpgrade" id="cdklabs-projen-project-types.CdklabsConstructLibraryOptions.property.depsUpgrade"></a>
-
-```typescript
-public readonly depsUpgrade: boolean;
-```
-
-- *Type:* boolean
-- *Default:* true
-
-Use tasks and github workflows to handle dependency upgrades.
-
-Cannot be used in conjunction with `dependabot`.
-
----
-
-##### `depsUpgradeOptions`<sup>Optional</sup> <a name="depsUpgradeOptions" id="cdklabs-projen-project-types.CdklabsConstructLibraryOptions.property.depsUpgradeOptions"></a>
-
-```typescript
-public readonly depsUpgradeOptions: UpgradeDependenciesOptions;
-```
-
-- *Type:* projen.javascript.UpgradeDependenciesOptions
-- *Default:* default options
-
-Options for `UpgradeDependencies`.
 
 ---
 

--- a/projenrc/cdk-construct-library-options.ts
+++ b/projenrc/cdk-construct-library-options.ts
@@ -23,6 +23,10 @@ export function generateCdkConstructLibraryOptions(project: typescript.TypeScrip
         },
       },
     },
+    omitProps: [
+      // These properties are ignored; a CdkLabsConstructLibrary does what it wants anyway.
+      'depsUpgrade', 'depsUpgradeOptions',
+    ],
     properties: [
       ...COMMON_OPTIONS,
       {

--- a/src/cdk-construct-library-options.ts
+++ b/src/cdk-construct-library-options.ts
@@ -295,17 +295,6 @@ export interface CdkConstructLibraryOptions {
    */
   readonly deps?: Array<string>;
   /**
-   * Use tasks and github workflows to handle dependency upgrades.
-   * Cannot be used in conjunction with `dependabot`.
-   * @default true
-   */
-  readonly depsUpgrade?: boolean;
-  /**
-   * Options for `UpgradeDependencies`.
-   * @default - default options
-   */
-  readonly depsUpgradeOptions?: javascript.UpgradeDependenciesOptions;
-  /**
    * The description is just a string that helps people understand the purpose of the package.
    * It can be used when searching for packages in a package manager as well.
    * See https://classic.yarnpkg.com/en/docs/package-json/#toc-description

--- a/src/common-options.ts
+++ b/src/common-options.ts
@@ -79,9 +79,12 @@ export function configureCommonComponents(project: typescript.TypeScriptProject,
     new UpgradeCdklabsProjenProjectTypes(project);
   }
 
-  if ((opts.upgradeRuntimeDepsAsFix)) {
+  if (opts.upgradeRuntimeDepsAsFix) {
     const exclude = opts.upgradeCdklabsProjenProjectTypes ? UpgradeCdklabsProjenProjectTypes.deps : [];
     const labels = opts.autoApproveUpgrades ? [opts.autoApproveOptions?.label ?? 'auto-approve'] : [];
+
+    // Run at 18:00Z once a week (on Monday)
+    const upgradeSchedule = javascript.UpgradeDependenciesSchedule.expressions(['0 18 * * 1']);
 
     new javascript.UpgradeDependencies(project, {
       taskName: 'upgrade',
@@ -94,7 +97,7 @@ export function configureCommonComponents(project: typescript.TypeScriptProject,
       semanticCommit: 'fix',
       workflowOptions: {
         labels,
-        schedule: javascript.UpgradeDependenciesSchedule.expressions(['0 18 * * *']),
+        schedule: upgradeSchedule,
       },
     });
 
@@ -106,6 +109,7 @@ export function configureCommonComponents(project: typescript.TypeScriptProject,
       pullRequestTitle: 'upgrade dev dependencies',
       workflowOptions: {
         labels,
+        schedule: upgradeSchedule,
       },
     });
   }

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -684,7 +684,7 @@ name: upgrade-dev-deps-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -778,7 +778,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 18 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -2519,7 +2519,7 @@ name: upgrade-dev-deps-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -2613,7 +2613,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 18 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -4193,7 +4193,7 @@ name: upgrade-dev-deps-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -4287,7 +4287,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 18 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -1006,7 +1006,7 @@ name: upgrade-dev-deps-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -1100,7 +1100,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 18 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -3329,7 +3329,7 @@ name: upgrade-dev-deps-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -3423,7 +3423,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 18 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -5080,7 +5080,7 @@ name: upgrade-dev-deps-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -5174,7 +5174,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 18 * * *
+    - cron: 0 18 * * 1
 jobs:
   upgrade:
     name: Upgrade


### PR DESCRIPTION
This reduces the automatic dependency upgrade frequency of CDKLabs repos to once a week instead of daily.

Motivation:

<img width="904" alt="image" src="https://github.com/user-attachments/assets/18e5d77e-d3b7-4f89-abc6-3ac4827e9a5f" />

Also remove the options that falsely give you an idea that this behavior can be configured on a per-repository basis. It cannot.