### PR TITLE
fix: gather-versions doesn't respect existing ranges

### DIFF
--- a/src/yarn/gather-versions.exec.ts
+++ b/src/yarn/gather-versions.exec.ts
@@ -1,54 +1,65 @@
 import { readFileSync, writeFileSync } from 'fs';
 
-function main() {
-  if (process.argv.includes('--help')) {
-    console.log('Usage: gather-versions [PACKAGE] [VERSION-MATCH] --deps [DEPENDENCIES]\n');
+export function cliMain() {
+  main(process.argv.slice(1), process.cwd());
+}
+
+export function main(argv: string[], packageDirectory: string) {
+  if (argv.includes('--help') || argv.length < 2) {
+    console.log('Usage: gather-versions [DEPENDENCIES]\n');
     console.log('Positionals:');
-    console.log('  PACKAGE\tThe name of the package to gather versions for');
-    console.log('  VERSION-MATCH\tHow dependency constraints are defined. One of: MAJOR (^), MINOR (~), EXACT');
     console.log('  DEPENDENCIES\tNames of the dependencies to gather versions from.');
     return;
   }
 
-  const [packageName, versionMatch, _dashDashDeps, ...deps] = process.argv.slice(1);
+  const [...deps] = argv;
 
-  const manifest = dependencyInfo(packageName);
+  // The PJ file we are updating
+  const targetPjFile = `${packageDirectory ?? '.'}/package.json`;
 
-  const prefix = versionConstraint(versionMatch);
+  const manifest = JSON.parse(readFileSync(targetPjFile, 'utf-8'));
+  const changeReport: any = {
+    name: manifest.name,
+    version: manifest.version,
+  };
 
   for (const dep of deps) {
-    const depVersion = dependencyInfo(dep).version;
-    console.log(dep, depVersion);
-    if (manifest.devDependencies?.[dep]) {
-      manifest.devDependencies[dep] = prefix + depVersion;
-    }
-    if (manifest.dependencies?.[dep]) {
-      manifest.dependencies[dep] = prefix + depVersion;
-    }
+    const depVersion = dependencyInfo(dep, packageDirectory).version;
 
-    writeFileSync('package.json', JSON.stringify(manifest, null, 2) + '\n');
+    for (const depSection of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      if (manifest[depSection]?.[dep]) {
+        manifest[depSection][dep] = replaceVersion(manifest[depSection][dep], depVersion);
+
+        changeReport[depSection] = {
+          ...changeReport[depSection],
+          [dep]: manifest[depSection][dep],
+        };
+      }
+    }
   }
+
+  // Print a report of what we did
+  console.log('New versions', JSON.stringify(changeReport, undefined, 2));
+
+  writeFileSync(targetPjFile, JSON.stringify(manifest, null, 2) + '\n');
 }
 
-function dependencyInfo(dependency: string): any {
+function dependencyInfo(dependency: string, searchDirectory: string): any {
   // Search needs to be w.r.t. the current directory, otherwise it is w.r.t. the current
   // file and that doesn't work if `cdklabs-projen-project-types` is locally symlinked.
-  return JSON.parse(readFileSync(require.resolve(`${dependency}/package.json`, { paths: [process.cwd()] })).toString());
-}
-
-function versionConstraint(versionMatch: string): string {
-  switch (versionMatch.toUpperCase()) {
-    case 'MAJOR':
-    case '^':
-      return '^';
-    case 'MINOR':
-    case '~':
-      return '~';
-    case 'EXACT':
-      return '';
-    default:
-      throw new Error(`Unknown VERSION-MATCH: ${versionMatch}`);
+  const pjLoc = require.resolve(`${dependency}/package.json`, { paths: [searchDirectory] });
+  if (!pjLoc) {
+    throw new Error(`Could not find ${dependency} in ${searchDirectory}`);
   }
+  return JSON.parse(readFileSync(pjLoc, 'utf-8'));
 }
 
-main();
+/**
+ * In a semver range, replace the string `0.0.0` with a different version
+ *
+ * If the semver range contains symbols like `^` or `>=`, they will be left
+ * in.
+ */
+function replaceVersion(versionRange: string, version: string): string {
+  return versionRange.replace(/0\.0\.0/g, version);
+}

--- a/src/yarn/gather-versions.task.ts
+++ b/src/yarn/gather-versions.task.ts
@@ -3,23 +3,17 @@ import { join } from 'node:path';
 import { TaskOptions, TaskStep } from 'projen';
 import { TypeScriptWorkspace } from './typescript-workspace';
 
-export enum VersionMatch {
-  MAJOR = 'MAJOR',
-  MINOR = 'MINOR',
-  EXACT = 'EXACT',
-}
-
 export class GatherVersions implements TaskOptions, TaskStep {
   public get exec(): string {
-    const main = `require(path.join(path.dirname(require.resolve('${currentPackageName()}')), 'yarn', 'gather-versions.exec.js'))`;
-    return `node -e "${main}" ${this.project.name} ${this.versionMatch} --deps ${this.project
+    const main = `require(path.join(path.dirname(require.resolve('${currentPackageName()}')), 'yarn', 'gather-versions.exec.js')).cliMain()`;
+    return `node -e "${main}" ${this.project
       .workspaceDependencies()
       .map((d) => d.name)
       .join(' ')}`;
   }
   public receiveArgs = true;
 
-  public constructor(public readonly project: TypeScriptWorkspace, public readonly versionMatch: VersionMatch) {}
+  public constructor(public readonly project: TypeScriptWorkspace) {}
 
   public toJSON() {
     return {

--- a/src/yarn/typescript-workspace-release.ts
+++ b/src/yarn/typescript-workspace-release.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 import { Component, ReleasableCommits, Task, Version, VersionBranchOptions, release } from 'projen';
-import { GatherVersions, VersionMatch } from './gather-versions.task';
+import { GatherVersions } from './gather-versions.task';
 import { TypeScriptWorkspace } from './typescript-workspace';
 
 export interface WorkspaceReleaseOptions {
@@ -74,7 +74,7 @@ export class WorkspaceRelease extends Component {
     // Therefor it is guaranteed that any local packages a package depends on,
     // already have been bumped.
     const gatherVersions = project.addTask('gather-versions', {
-      steps: [new GatherVersions(project, VersionMatch.MAJOR)],
+      steps: [new GatherVersions(project)],
     });
 
     const bumpTask = this.obtainBumpTask();

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -3962,7 +3962,7 @@ tsconfig.tsbuildinfo
         "name": "gather-versions",
         "steps": [
           {
-            "exec": "node -e "require(path.join(path.dirname(require.resolve('cdklabs-projen-project-types')), 'yarn', 'gather-versions.exec.js'))" @cdklabs/one MAJOR --deps ",
+            "exec": "node -e "require(path.join(path.dirname(require.resolve('cdklabs-projen-project-types')), 'yarn', 'gather-versions.exec.js')).cliMain()" ",
             "receiveArgs": true,
           },
         ],
@@ -4851,7 +4851,7 @@ tsconfig.tsbuildinfo
         "name": "gather-versions",
         "steps": [
           {
-            "exec": "node -e "require(path.join(path.dirname(require.resolve('cdklabs-projen-project-types')), 'yarn', 'gather-versions.exec.js'))" @cdklabs/two MAJOR --deps ",
+            "exec": "node -e "require(path.join(path.dirname(require.resolve('cdklabs-projen-project-types')), 'yarn', 'gather-versions.exec.js')).cliMain()" ",
             "receiveArgs": true,
           },
         ],

--- a/test/gather-versions.test.ts
+++ b/test/gather-versions.test.ts
@@ -1,0 +1,83 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { main } from '../src/yarn/gather-versions.exec';
+
+// Test the actual gather-versions script
+test('gather-versions updates all package versions respecting existing ranges', async () => {
+  await withTempDir(async (dir) => {
+    await writeJsonFiles(dir, {
+      'node_modules/depA/package.json': {
+        name: 'depA',
+        version: '1.2.3',
+      },
+      'node_modules/depB/package.json': {
+        name: 'depB',
+        version: '4.5.6',
+      },
+      'node_modules/depC/package.json': {
+        name: 'depC',
+        version: '7.8.9',
+      },
+      'package.json': {
+        name: 'root',
+        dependencies: {
+          depA: '0.0.0',
+        },
+        devDependencies: {
+          depB: '^0.0.0',
+        },
+        peerDependencies: {
+          depC: '>= 0.0.0',
+        },
+      },
+    });
+
+    // WHEN
+    main(['depA', 'depB', 'depC'], dir);
+
+    // THEN
+    expect(JSON.parse(await fs.readFile(path.join(dir, 'package.json'), 'utf-8'))).toEqual({
+      name: 'root',
+      dependencies: {
+        depA: '1.2.3',
+      },
+      devDependencies: {
+        depB: '^4.5.6',
+      },
+      peerDependencies: {
+        depC: '>= 7.8.9',
+      },
+    });
+  });
+});
+
+/**
+ * Runs an async function in a temporary directory that gets cleaned up afterwards
+ */
+async function withTempDir<T>(
+  fn: (tempDir: string) => Promise<T>,
+): Promise<T> {
+  const oldCwd = process.cwd();
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'temp-'));
+  try {
+    return await fn(tempDir);
+  } finally {
+    process.chdir(oldCwd);
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Writes JSON files to disk based on a mapping of filenames to data
+ */
+async function writeJsonFiles(root: string, files: Record<string, any>): Promise<void> {
+  await Promise.all(
+    Object.entries(files).map(async ([filename, data]) => {
+      const fullPath = path.join(root, filename);
+
+      await fs.mkdir(path.dirname(fullPath), { recursive: true });
+      await fs.writeFile(fullPath, JSON.stringify(data, null, 2), 'utf-8');
+    }),
+  );
+}


### PR DESCRIPTION
Upon bumping, `gather-versions` script rewrites all dependency ranges with a caret (`^`), rather than respecting the dependency types that are already in the `package.json` file.

Instead, only replace the `0.0.0` string with the actual version, leaving the rest.
