### PR TITLE
fix: gather-versions doesn't work for 0 or 1 dependencies

### DIFF
--- a/src/yarn/gather-versions.exec.ts
+++ b/src/yarn/gather-versions.exec.ts
@@ -5,11 +5,12 @@ export function cliMain() {
 }
 
 export function main(argv: string[], packageDirectory: string) {
-  if (argv.includes('--help') || argv.length < 2) {
-    console.log('Usage: gather-versions PKG=TYPE [PKG=TYPE] [...]\n');
-    console.log('Positionals:');
-    console.log('  PKG\tPackage name.');
-    console.log('  TYPE\tmajor | minor | exact | minimal');
+  if (argv.includes('--help')) {
+    console.error('Usage: gather-versions [PKG=TYPE] [PKG=TYPE] [...]\n');
+    console.error('Positionals:');
+    console.error('  PKG\tPackage name.');
+    console.error('  TYPE\tmajor | minor | exact | minimal');
+    process.exitCode = 1;
     return;
   }
 
@@ -55,7 +56,7 @@ export function main(argv: string[], packageDirectory: string) {
   }
 
   // Print a report of what we did
-  console.log('New versions', JSON.stringify(changeReport, undefined, 2));
+  console.log('Updated versions', JSON.stringify(changeReport, undefined, 2));
 
   writeFileSync(targetPjFile, JSON.stringify(manifest, null, 2) + '\n');
 }

--- a/src/yarn/gather-versions.task.ts
+++ b/src/yarn/gather-versions.task.ts
@@ -32,7 +32,8 @@ export class GatherVersions implements TaskOptions, TaskStep {
   }
 
   public get exec(): string {
-    const main = `require(path.join(path.dirname(require.resolve('${currentPackageName()}')), 'yarn', 'gather-versions.exec.js')).cliMain()`;
+    // We must resolve paths at runtime to avoid writing '/home/$USER/...' into the `tasks.json` file
+    const main = `require(require.resolve('${currentPackageName()}/lib/yarn/gather-versions.exec.js')).cliMain()`;
     return `node -e "${main}" ${Object.entries(this.repoDependencies).map(([d, r]) => `${d}=${r}`)}`;
   }
 

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -3962,7 +3962,7 @@ tsconfig.tsbuildinfo
         "name": "gather-versions",
         "steps": [
           {
-            "exec": "node -e "require(path.join(path.dirname(require.resolve('cdklabs-projen-project-types')), 'yarn', 'gather-versions.exec.js')).cliMain()" ",
+            "exec": "node -e "require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()" ",
             "receiveArgs": true,
           },
         ],
@@ -4851,7 +4851,7 @@ tsconfig.tsbuildinfo
         "name": "gather-versions",
         "steps": [
           {
-            "exec": "node -e "require(path.join(path.dirname(require.resolve('cdklabs-projen-project-types')), 'yarn', 'gather-versions.exec.js')).cliMain()" ",
+            "exec": "node -e "require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()" ",
             "receiveArgs": true,
           },
         ],

--- a/test/gather-versions.test.ts
+++ b/test/gather-versions.test.ts
@@ -2,6 +2,9 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { main } from '../src/yarn/gather-versions.exec';
+import { yarn } from '../src';
+import { Project, TaskRuntime } from 'projen';
+import { TypeScriptWorkspaceOptions } from '../src/yarn';
 
 // Test the actual gather-versions script
 test('gather-versions updates all package versions respecting existing ranges', async () => {
@@ -54,6 +57,47 @@ test('gather-versions updates all package versions respecting existing ranges', 
   });
 });
 
+const NO_DEVDEPS: Partial<TypeScriptWorkspaceOptions> = {
+  // We're actually installing these, so cut down on deps
+  jest: false,
+  eslint: false,
+  prettier: false,
+};
+
+test('make sure a run of gather-versions writes the right version to package.json', async () => {
+  // GIVEN
+  const parent = new yarn.CdkLabsMonorepo({
+    name: 'monorepo',
+    defaultReleaseBranch: 'main',
+    release: true,
+  });
+
+  const dep = new yarn.TypeScriptWorkspace({
+    parent,
+    name: '@cdklabs/one',
+    ...NO_DEVDEPS,
+  });
+
+  // WHEN
+  const pack = new yarn.TypeScriptWorkspace({
+    parent,
+    name: '@cdklabs/two',
+    deps: [dep.customizeReference({ versionType: 'exact' })],
+    ...NO_DEVDEPS,
+  });
+
+  // THEN
+  parent.synth();
+  // Running this script requires the package to have been compiled before we see any updates to the script
+  await addSymlinkToMe(parent);
+  new TaskRuntime(pack.outdir).runTask('gather-versions');
+
+  const packageJson = JSON.parse(await fs.readFile(path.join(pack.outdir, 'package.json'), 'utf-8'));
+  expect(Object.entries(packageJson.dependencies)).toContainEqual([
+    '@cdklabs/one', '0.0.0',
+  ]);
+}, 60_000); // Needs to install real packages
+
 /**
  * Runs an async function in a temporary directory that gets cleaned up afterwards
  */
@@ -82,4 +126,17 @@ async function writeJsonFiles(root: string, files: Record<string, any>): Promise
       await fs.writeFile(fullPath, JSON.stringify(data, null, 2), 'utf-8');
     }),
   );
+}
+
+/**
+ * (Temporarily) symlink this package into the `node_modules` directory of a project.
+ *
+ * This is necessary because running our script does a `require.resolve('cdklabs-projen-project-types')`.
+ */
+async function addSymlinkToMe(project: Project) {
+  const pkgRoot = path.join(__dirname, '..');
+
+  const name = JSON.parse(await fs.readFile(`${pkgRoot}/package.json`, 'utf-8')).name;
+  const symlinkName = `${project.outdir}/node_modules/${name}`;
+  await fs.symlink(pkgRoot, symlinkName);
 }

--- a/test/gather-versions.test.ts
+++ b/test/gather-versions.test.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { main } from '../src/yarn/gather-versions.exec';
-import { yarn } from '../src';
 import { Project, TaskRuntime } from 'projen';
+import { yarn } from '../src';
 import { TypeScriptWorkspaceOptions } from '../src/yarn';
+import { main } from '../src/yarn/gather-versions.exec';
 
 // Test the actual gather-versions script
 test('gather-versions updates all package versions respecting existing ranges', async () => {


### PR DESCRIPTION
When I simplified the command-line that `gather-versions` takes, I forgot to take out the condition that requires a minimum number of arguments.

The result is that `gather-versions` won't do anything thing for packages that have 0 or 1 workspace dependency; plus, the script didn't actually exit with an error code when that happened, so it was hard to detect.

Fix that in this PR, and also add a test that runs the `gather-versions` task properly from a projen monorepo config using `TaskRuntime`.
