### PR TITLE
fix(monorepo): gather-versions leaves repo in a state with diffs

### DIFF
--- a/src/yarn/gather-versions.exec.ts
+++ b/src/yarn/gather-versions.exec.ts
@@ -10,9 +10,13 @@ export function main(argv: string[], packageDirectory: string) {
     console.error('Positionals:');
     console.error('  PKG\tPackage name.');
     console.error('  TYPE\tmajor | minor | exact | minimal');
+    console.error('');
+    console.error('If $RESET_VERSIONS is "true", ignore the version specifier and just reset all packages to ^0.0.0');
     process.exitCode = 1;
     return;
   }
+
+  const isReset = process.env.RESET_VERSIONS === 'true';
 
   const deps = Object.fromEntries(argv.map(x => x.split('=', 2) as [string, string]));
 
@@ -39,7 +43,8 @@ export function main(argv: string[], packageDirectory: string) {
     ];
 
     for (const [depSection, prefix] of dependencyClasses) {
-      const updatedRange = prefix + depVersion;
+      const bumpForward = !isReset;
+      const updatedRange = bumpForward ? prefix + depVersion : '^0.0.0';
 
       if (manifest[depSection]?.[dep]) {
         manifest[depSection][dep] = updatedRange;

--- a/src/yarn/typescript-workspace-release.ts
+++ b/src/yarn/typescript-workspace-release.ts
@@ -102,9 +102,17 @@ export class WorkspaceRelease extends Component {
     }
 
 
-    // After we have unbumped package versions back to 0.0.0,
-    // we can run the gather-versions task again which will now replace the to-be-release versions with 0.0.0
-    this.obtainUnbumpTask().spawn(gatherVersions);
+    // After we have unbumped package versions back to ^0.0.0,
+    // we can run the gather-versions task again which will now replace the to-be-release versions with ^0.0.0
+    //
+    // We need to set an environment variable to get `gatherVersions` to behave differently in the unbump
+    // invocation (in the bump invocation, it may change the package.json dependency range from `^0.0.0` to `1.2.3`;
+    // using a different range symbol), but when unbumping it must always reset back to the `^0.0.0` version.
+    this.obtainUnbumpTask().spawn(gatherVersions, {
+      env: {
+        RESET_VERSIONS: 'true',
+      },
+    });
   }
 
   /**

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -4078,6 +4078,9 @@ tsconfig.tsbuildinfo
             "builtin": "release/reset-version",
           },
           {
+            "env": {
+              "RESET_VERSIONS": "true",
+            },
             "spawn": "gather-versions",
           },
         ],
@@ -4967,6 +4970,9 @@ tsconfig.tsbuildinfo
             "builtin": "release/reset-version",
           },
           {
+            "env": {
+              "RESET_VERSIONS": "true",
+            },
             "spawn": "gather-versions",
           },
         ],

--- a/test/gather-versions.test.ts
+++ b/test/gather-versions.test.ts
@@ -57,6 +57,36 @@ test('gather-versions updates all package versions respecting existing ranges', 
   });
 });
 
+test('if RESET_VERSIONS is true, gather-versions ignores command line and reverts ^0.0.0', async () => {
+  await withTempDir(async (dir) => {
+    await writeJsonFiles(dir, {
+      'node_modules/depA/package.json': {
+        name: 'depA',
+        version: '0.0.0',
+      },
+      'package.json': {
+        name: 'root',
+        dependencies: {
+          depA: '1.2.3',
+        },
+      },
+    });
+
+    // WHEN
+    process.env.RESET_VERSIONS = 'true';
+    main(['depA=exact'], dir);
+    delete process.env.RESET_VERSIONS;
+
+    // THEN
+    expect(JSON.parse(await fs.readFile(path.join(dir, 'package.json'), 'utf-8'))).toEqual({
+      name: 'root',
+      dependencies: {
+        depA: '^0.0.0',
+      },
+    });
+  });
+});
+
 const NO_DEVDEPS: Partial<TypeScriptWorkspaceOptions> = {
   // We're actually installing these, so cut down on deps
   jest: false,


### PR DESCRIPTION
Releasing currently doesn't work since the monorepo release workflow changes `package.json` with exact references to monorepo packages like this:

```js
{ "monorepoDep": "^0.0.0"  }

// --> bump

{ "monorepoDep": "2.100.0"  }

// --> unbump

{ "monorepoDep": "0.0.0"  }
```

Which counts as a git diff and the `release` step fails.
