### PR TITLE
fix: assume role session duration not compatible with atmosphere

### DIFF
--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -310,7 +310,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
           uses: 'aws-actions/configure-aws-credentials@v4',
           with: {
             'aws-region': 'us-east-1',
-            'role-duration-seconds': 4 * 60 * 60,
+            'role-duration-seconds': props.enableAtmosphere ? 60 * 60 : 4 * 60 * 60,
             // Expect this in Environment Variables
             'role-to-assume': props.enableAtmosphere ? props.enableAtmosphere.oidcRoleArn : '${{ vars.AWS_ROLE_TO_ASSUME_FOR_TESTING }}',
             'role-session-name': 'run-tests@aws-cdk-cli-integ',

--- a/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
+++ b/test/__snapshots__/cdk-cli-integ-tests.test.ts.snap
@@ -1227,7 +1227,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
-          role-duration-seconds: 14400
+          role-duration-seconds: 3600
           role-to-assume: oidcRoleArn
           role-session-name: run-tests@aws-cdk-cli-integ
           output-credentials: true


### PR DESCRIPTION
The OIDC role created by atmosphere has a max duration of one hour, which is plenty. 