### PR TITLE
feat: add maxWorkers option to CdkCliIntegTestsWorkflow

### DIFF
--- a/API.md
+++ b/API.md
@@ -14847,6 +14847,7 @@ const cdkCliIntegTestsWorkflowProps: CdkCliIntegTestsWorkflowProps = { ... }
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.testRunsOn">testRunsOn</a></code> | <code>string</code> | Runners for the workflow. |
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.allowUpstreamVersions">allowUpstreamVersions</a></code> | <code>string[]</code> | If given, allows accessing upstream versions of these packages. |
 | <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.enableAtmosphere">enableAtmosphere</a></code> | <code><a href="#cdklabs-projen-project-types.AtmosphereOptions">AtmosphereOptions</a></code> | Enable atmosphere service to retrieve AWS test environments. |
+| <code><a href="#cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.maxWorkers">maxWorkers</a></code> | <code>string</code> | Specifies the maximum number of workers the worker-pool will spawn for running tests. |
 
 ---
 
@@ -14955,6 +14956,19 @@ public readonly enableAtmosphere: AtmosphereOptions;
 - *Default:* atmosphere is not used
 
 Enable atmosphere service to retrieve AWS test environments.
+
+---
+
+##### `maxWorkers`<sup>Optional</sup> <a name="maxWorkers" id="cdklabs-projen-project-types.CdkCliIntegTestsWorkflowProps.property.maxWorkers"></a>
+
+```typescript
+public readonly maxWorkers: string;
+```
+
+- *Type:* string
+- *Default:* the cli integ test package determines a sensible default
+
+Specifies the maximum number of workers the worker-pool will spawn for running tests.
 
 ---
 

--- a/src/cdk-cli-integ-tests.ts
+++ b/src/cdk-cli-integ-tests.ts
@@ -75,6 +75,14 @@ export interface CdkCliIntegTestsWorkflowProps {
    * @default - atmosphere is not used
    */
   readonly enableAtmosphere?: AtmosphereOptions;
+
+
+  /**
+   * Specifies the maximum number of workers the worker-pool will spawn for running tests.
+   *
+   * @default - the cli integ test package determines a sensible default
+   */
+  readonly maxWorkers?: string;
 }
 
 /**
@@ -119,6 +127,11 @@ export class CdkCliIntegTestsWorkflow extends Component {
         throw new Error(`Package in allowUpstreamVersions but not in localPackages: ${pack}`);
       }
     });
+
+    let maxWorkersArg = '';
+    if (props.maxWorkers) {
+      maxWorkersArg = ` --maxWorkers=${props.maxWorkers}`;
+    }
 
     runTestsWorkflow.on({
       pullRequestTarget: {
@@ -384,7 +397,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
         {
           name: 'Run the test suite: ${{ matrix.suite }}',
           run: [
-            'bin/run-suite --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}',
+            `bin/run-suite${maxWorkersArg} --use-cli-release=\${{ steps.versions.outputs.cli_version }} --framework-version=\${{ steps.versions.outputs.lib_version }} \${{ matrix.suite }}`,
           ].join('\n'),
           env: {
             JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: 'true',

--- a/test/cdk-cli-integ-tests.test.ts
+++ b/test/cdk-cli-integ-tests.test.ts
@@ -45,3 +45,23 @@ test('snapshot test for the CDK CLI integ tests using atmosphere', () => {
   const outdir = Testing.synth(repo);
   expect(outdir).toMatchSnapshot();
 });
+
+test('can set maxworkers', () => {
+  const repo = new yarn.CdkLabsMonorepo({
+    name: 'monorepo',
+    defaultReleaseBranch: 'main',
+  });
+
+  new CdkCliIntegTestsWorkflow(repo, {
+    approvalEnvironment: 'approval',
+    testEnvironment: 'test',
+    buildRunsOn: 'runsOn',
+    testRunsOn: 'testRunsOn',
+    localPackages: ['@aws-cdk/bla', '@aws-cdk/bloeh'],
+    sourceRepo: 'aws/some-repo',
+    maxWorkers: '500',
+  });
+
+  const outdir = Testing.synth(repo);
+  expect(outdir['.github/workflows/integ.yml']).toContain('run: bin/run-suite --maxWorkers=500 --use-cli-release=');
+});


### PR DESCRIPTION
This PR adds a new option to the CdkCliIntegTestsWorkflow component that allows specifying the maximum number of workers for running integration tests. 

The new  property is optional and when provided, it adds the `--maxWorkers` flag to the test command with the specified value.

This gives users more control over test parallelization in their CI workflows.