### PR TITLE
feat: add support for selective releases

### DIFF
--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -2779,7 +2779,13 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      package_list:
+        description: JSON array of packages to selectively release
+        required: false
+        type: string
+        default: "[]"
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -2787,8 +2793,8 @@ jobs:
       contents: write
     outputs:
       latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
-      publish-cdklabs-one: \${{ steps.check-publish-cdklabs-one.outputs.publish }}
-      publish-cdklabs-two: \${{ steps.check-publish-cdklabs-two.outputs.publish }}
+      publish-cdklabs-one: \${{ steps.check-publish-cdklabs-one && (fromJSON(inputs.package_list || '[]')[0] == null || contains(fromJSON(inputs.package_list || '[]'), '@cdklabs/one')).outputs.publish }}
+      publish-cdklabs-two: \${{ steps.check-publish-cdklabs-two && (fromJSON(inputs.package_list || '[]')[0] == null || contains(fromJSON(inputs.package_list || '[]'), '@cdklabs/two')).outputs.publish }}
     env:
       CI: "true"
     steps:


### PR DESCRIPTION
Add a user interface option to do selective releasing in the GitHub workflow.

This adds a string input that should hold a JSON array with the packages to release. If the array is empty (or the input is not present), then we release all packages.

I would have loved to do checkboxes for every package, but there is a maximum of 10 inputs for a workflow and I don't want to suddenly fall off a cliff for certain repos.

We do the build for all packages, but hook into the "needs-publish" step to add this condition into that expression:

```yaml
    outputs:
      publish-xyz: ${{ steps.check-publish-xyz.outputs.publish }}
```

to

```yaml
    outputs:
      publish-xyz: ${{ steps.check-xyzy-schema.outputs.publish && (fromJSON(inputs.package_list || '[]')[0] == null || contains(fromJSON(inputs.package_list || '[]'), 'xyz')).outputs.publish }}
```

I'm not sure how to best test this, except doing it for real in a low-risk repo (like the service spec repo).

