### PR TITLE
fix: TypeScript workspaces bring in conflicting projen dependencies

### DIFF
--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -247,6 +247,9 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
 
     this.bundledDeps.push(...options.bundledDeps ?? []);
 
+    // Individual workspace packages shouldn't depend on "projen", it gets brought in at the monorepo root
+    this.deps.removeDependency('projen');
+
     options.parent.register(this);
   }
 

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -1155,10 +1155,6 @@ tsconfig.tsbuildinfo
         "type": "build",
       },
       {
-        "name": "projen",
-        "type": "build",
-      },
-      {
         "name": "ts-jest",
         "type": "build",
       },
@@ -1220,7 +1216,7 @@ tsconfig.tsbuildinfo
         "name": "check-for-updates",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,projen,ts-jest,typescript",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
           },
         ],
       },
@@ -1547,7 +1543,6 @@ tsconfig.tsbuildinfo
       "jest": "*",
       "jest-junit": "^16",
       "prettier": "*",
-      "projen": "*",
       "ts-jest": "*",
       "typescript": "*",
     },
@@ -1974,10 +1969,6 @@ tsconfig.tsbuildinfo
         "type": "build",
       },
       {
-        "name": "projen",
-        "type": "build",
-      },
-      {
         "name": "ts-jest",
         "type": "build",
       },
@@ -2039,7 +2030,7 @@ tsconfig.tsbuildinfo
         "name": "check-for-updates",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,projen,ts-jest,typescript",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
           },
         ],
       },
@@ -2366,7 +2357,6 @@ tsconfig.tsbuildinfo
       "jest": "*",
       "jest-junit": "^16",
       "prettier": "*",
-      "projen": "*",
       "ts-jest": "*",
       "typescript": "*",
     },
@@ -3867,10 +3857,6 @@ tsconfig.tsbuildinfo
         "type": "build",
       },
       {
-        "name": "projen",
-        "type": "build",
-      },
-      {
         "name": "ts-jest",
         "type": "build",
       },
@@ -3955,7 +3941,7 @@ tsconfig.tsbuildinfo
         "name": "check-for-updates",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,projen,ts-jest,typescript",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
           },
         ],
       },
@@ -4317,7 +4303,6 @@ tsconfig.tsbuildinfo
       "jest": "*",
       "jest-junit": "^16",
       "prettier": "*",
-      "projen": "*",
       "ts-jest": "*",
       "typescript": "*",
     },
@@ -4759,10 +4744,6 @@ tsconfig.tsbuildinfo
         "type": "build",
       },
       {
-        "name": "projen",
-        "type": "build",
-      },
-      {
         "name": "ts-jest",
         "type": "build",
       },
@@ -4847,7 +4828,7 @@ tsconfig.tsbuildinfo
         "name": "check-for-updates",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,projen,ts-jest,typescript",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
           },
         ],
       },
@@ -5209,7 +5190,6 @@ tsconfig.tsbuildinfo
       "jest": "*",
       "jest-junit": "^16",
       "prettier": "*",
-      "projen": "*",
       "ts-jest": "*",
       "typescript": "*",
     },
@@ -6503,10 +6483,6 @@ tsconfig.tsbuildinfo
         "type": "build",
       },
       {
-        "name": "projen",
-        "type": "build",
-      },
-      {
         "name": "ts-jest",
         "type": "build",
       },
@@ -6568,7 +6544,7 @@ tsconfig.tsbuildinfo
         "name": "check-for-updates",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,projen,ts-jest,typescript",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
           },
         ],
       },
@@ -6895,7 +6871,6 @@ tsconfig.tsbuildinfo
       "jest": "*",
       "jest-junit": "^16",
       "prettier": "*",
-      "projen": "*",
       "ts-jest": "*",
       "typescript": "*",
     },

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -28,6 +28,19 @@ describe('CdkLabsMonorepo', () => {
       expect(outdir).toMatchSnapshot();
     });
 
+    test('workspaces dont have their own projen dependency', () => {
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/one',
+      });
+
+      const outdir = Testing.synth(parent);
+      const deps = outdir['packages/@cdklabs/one/.projen/deps.json'];
+      expect(deps.dependencies).not.toContain(expect.objectContaining({
+        name: 'projen',
+      }));
+    });
+
     test('bundled dependencies lead to a nohoist directive', () => {
       // GIVEN
       new yarn.TypeScriptWorkspace({


### PR DESCRIPTION
This only opens up the possibility of multiple projen versions across the monorepo, which is a source of bugs.