### PR TITLE
feat(yarn)!: add extended version types for workspace references

### DIFF
--- a/API.md
+++ b/API.md
@@ -35511,7 +35511,7 @@ public readonly versionType: string;
 ```
 
 - *Type:* string
-- *Default:* 'major'
+- *Default:* 'future-minor'
 
 What type of dependency to take on this package.
 

--- a/src/yarn/gather-versions.exec.ts
+++ b/src/yarn/gather-versions.exec.ts
@@ -9,7 +9,7 @@ export function main(argv: string[], packageDirectory: string) {
     console.error('Usage: gather-versions [PKG=TYPE] [PKG=TYPE] [...]\n');
     console.error('Positionals:');
     console.error('  PKG\tPackage name.');
-    console.error('  TYPE\tmajor | minor | exact | minimal | current-major | current-minor | any');
+    console.error('  TYPE\tany-minor | future-minor | any-patch | future-patch | exact | any-future | any');
     console.error('');
     console.error('If $RESET_VERSIONS is "true", ignore the version specifier and just reset all packages to ^0.0.0');
     process.exitCode = 1;
@@ -79,10 +79,10 @@ function versionForRange(depType: string, version: string) {
   const runtimePrefix = prefixFromRange(depType);
 
   switch (depType) {
-    case 'major':
-    case 'minor':
+    case 'future-minor':
+    case 'future-patch':
+    case 'any-future':
     case 'exact':
-    case 'minimal':
       return runtimePrefix + version;
     case 'any':
       return '*';
@@ -90,9 +90,9 @@ function versionForRange(depType: string, version: string) {
 
   const details = semver(version);
   switch (depType) {
-    case 'current-major':
+    case 'any-minor':
       return `${runtimePrefix}${details.major}`;
-    case 'current-minor':
+    case 'any-patch':
       return `${runtimePrefix}${details.major}.${details.minor}`;
   }
 
@@ -121,16 +121,16 @@ function semver(version: string) {
 
 function prefixFromRange(x: string): string {
   switch (x) {
-    case 'current-major':
-    case 'major':
+    case 'any-minor':
+    case 'future-minor':
       return '^';
-    case 'current-minor':
-    case 'minor':
+    case 'any-patch':
+    case 'future-patch':
       return '~';
     case 'any':
     case 'exact':
       return '';
-    case 'minimal':
+    case 'any-future':
       return '>=';
     default:
       throw new Error(`Unknown range type: ${x}`);

--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -7,15 +7,15 @@ import { TypeScriptWorkspaceOptions } from './typescript-workspace-options';
 /**
  * What kind of semver dependency to take
  *
- * - 'major' corresponds to '^1.2.3'
- * - 'current-major' corresponds to '^1'
- * - 'minor' to '~1.2.3'
- * - 'current-minor' corresponds to '~1.2'
+ * - 'any-minor' corresponds to '^1'
+ * - 'future-minor' corresponds to '^1.2.3'
+ * - 'any-patch' to '~1.2'
+ * - 'future-patch' corresponds to '~1.2.3'
  * - 'exact' corresponds to '1.2.3'
- * - 'minimal' corresponds to '>=1.2.3'
+ * - 'any-future' corresponds to '>=1.2.3'
  * - 'any' corresponds to '*'
  */
-export type VersionType = 'major' | 'minor' | 'exact' | 'minimal' | 'current-major' | 'current-minor' | 'any';
+export type VersionType = 'any-minor' | 'future-minor' | 'any-patch' | 'future-patch' | 'exact' | 'any-future' | 'any';
 
 /**
  * A reference to a workspace in the same monorepo
@@ -58,7 +58,7 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
   public readonly workspaceDirectory: string;
   public readonly bundledDeps: string[] = [];
   public readonly isPrivatePackage: boolean;
-  public readonly versionType = 'major';
+  public readonly versionType = 'future-minor';
 
   private readonly monorepo: Monorepo;
 
@@ -323,7 +323,7 @@ export interface ReferenceOptions {
    *
    * Choose a different range type to take, for example, an `exact` dependency.
    *
-   * @default 'major'
+   * @default 'future-minor'
    */
   readonly versionType?: VersionType;
 }

--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -7,12 +7,15 @@ import { TypeScriptWorkspaceOptions } from './typescript-workspace-options';
 /**
  * What kind of semver dependency to take
  *
- * - 'major' corresponds to '^'
- * - 'minor' to '~'
- * - 'exact' to ''
- * - 'minimal' to '>='
+ * - 'major' corresponds to '^1.2.3'
+ * - 'current-major' corresponds to '^1'
+ * - 'minor' to '~1.2.3'
+ * - 'current-minor' corresponds to '~1.2'
+ * - 'exact' corresponds to '1.2.3'
+ * - 'minimal' corresponds to '>=1.2.3'
+ * - 'any' corresponds to '*'
  */
-export type VersionType = 'major' | 'minor' | 'exact' | 'minimal';
+export type VersionType = 'major' | 'minor' | 'exact' | 'minimal' | 'current-major' | 'current-minor' | 'any';
 
 /**
  * A reference to a workspace in the same monorepo

--- a/test/gather-versions.test.ts
+++ b/test/gather-versions.test.ts
@@ -38,7 +38,7 @@ test('gather-versions updates all package versions respecting existing ranges', 
     });
 
     // WHEN
-    main(['depA=exact', 'depB=major', 'depC=minimal'], dir);
+    main(['depA=exact', 'depB=future-minor', 'depC=any-future'], dir);
 
     // THEN
     expect(JSON.parse(await fs.readFile(path.join(dir, 'package.json'), 'utf-8'))).toEqual({
@@ -134,12 +134,12 @@ test.each([0, 1, 2])('make sure gather-versions works for %p dependencies', asyn
 
 test('gather-versions with different reference types', async () => {
   const expected: Record<VersionType, string> = {
-    'major': '^0.0.0',
-    'minor': '~0.0.0',
+    'any-minor': '^0',
+    'future-minor': '^0.0.0',
+    'any-patch': '~0.0',
+    'future-patch': '~0.0.0',
     'exact': '0.0.0',
-    'minimal': '>=0.0.0',
-    'current-major': '^0',
-    'current-minor': '~0.0',
+    'any-future': '>=0.0.0',
     'any': '*',
   };
 


### PR DESCRIPTION
Adds support for new and updated version types for workspace references, to allow for more flexible dependencies between packages in a monorepo:

- `any-minor` => `^1`
- `future-minor` => `^1.2.3`
- `any-patch` => `~1.2`
- `future-patch` => `~1.2.3`
- `exact` => `1.2.3`
- `any-future` => `>=1.2.3`
- `any` => `*`


The current types 'major' (=> `future-minor`), 'minor' (=> `future-patch`, 'minimal' (=> `any-future`) are renamed to more accurately reflect their effect.