### PR TITLE
feat: trusted publishers

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,4 @@ The location the workspace is placed at. Defaults to `./packages`
 - `excludeDepsFromUpgrade: Array<string>`\
 List any dependencies that should not be updated in the workspace.
 
+


### PR DESCRIPTION
In https://github.com/cdklabs/cdklabs-projen-project-types/pull/870, the package with updated with a new `npmTrustedPublishers` property [that was introduced to projen](https://github.com/projen/projen/pull/4321), we would like to start using this property in the CLI repository. 

Problem is, the PR didn't trigger a release because it was a `chore`. We should fix our releasable commits mechanism - but for now, i'd like to force a release.  

So this PR has no changes, expect it is marked with `feat`, so it will trigger a release. 