### PR TITLE
fix: `npmTrustedPublishing` and `releaseEnvironment` are ignored in `TypeScriptWorkspace`

### DIFF
--- a/API.md
+++ b/API.md
@@ -38550,8 +38550,10 @@ const workspaceReleaseOptions: yarn.WorkspaceReleaseOptions = { ... }
 | --- | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.private">private</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.versionBranchOptions">versionBranchOptions</a></code> | <code>projen.VersionBranchOptions</code> | *No description.* |
+| <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.environment">environment</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.nextVersionCommand">nextVersionCommand</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.npmDistTag">npmDistTag</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.publishToNpm">publishToNpm</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.releasableCommits">releasableCommits</a></code> | <code>projen.ReleasableCommits</code> | *No description.* |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.repoRuntimeDependencies">repoRuntimeDependencies</a></code> | <code>{[ key: string ]: string}</code> | For runtime and peer dependencies, the type of dependency we take on each package. |
@@ -38579,6 +38581,16 @@ public readonly versionBranchOptions: VersionBranchOptions;
 
 ---
 
+##### `environment`<sup>Optional</sup> <a name="environment" id="cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.environment"></a>
+
+```typescript
+public readonly environment: string;
+```
+
+- *Type:* string
+
+---
+
 ##### `nextVersionCommand`<sup>Optional</sup> <a name="nextVersionCommand" id="cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.nextVersionCommand"></a>
 
 ```typescript
@@ -38596,6 +38608,16 @@ public readonly npmDistTag: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="cdklabs-projen-project-types.yarn.WorkspaceReleaseOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
 
 ---
 

--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -85,6 +85,7 @@ export class MonorepoRelease extends Component {
             minMajorVersion: options.versionBranchOptions.minMajorVersion ?? this.options.minMajorVersion,
             prerelease: options.versionBranchOptions.prerelease ?? this.options.prerelease,
             npmDistTag: options.npmDistTag ?? this.options.npmDistTag,
+            environment: options.environment,
           },
         },
       });

--- a/src/yarn/typescript-workspace-release.ts
+++ b/src/yarn/typescript-workspace-release.ts
@@ -12,6 +12,8 @@ export interface WorkspaceReleaseOptions {
   readonly npmDistTag?: string;
   readonly releasableCommits?: ReleasableCommits;
   readonly nextVersionCommand?: string;
+  readonly npmTrustedPublishing?: boolean;
+  readonly environment?: string;
   readonly versionBranchOptions: VersionBranchOptions;
 
   /**
@@ -70,6 +72,7 @@ export class WorkspaceRelease extends Component {
           registry: project.package.npmRegistry,
           npmTokenSecret: project.package.npmTokenSecret,
           npmProvenance: project.package.npmProvenance,
+          trustedPublishing: options.npmTrustedPublishing,
         });
       }
     }

--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -81,7 +81,7 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
     const usePrettier = remainder.prettier ?? true;
 
     const wsScope = remainder.workspaceScope ?? 'packages';
-    const workspaceDirectory =`${wsScope}/${options.name}`;
+    const workspaceDirectory = `${wsScope}/${options.name}`;
 
     const npmAccess = options.parent.monorepoRelease && !options.private ? javascript.NpmAccess.PUBLIC : undefined;
 
@@ -164,6 +164,8 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
       private: this.isPrivatePackage,
       workflowNodeVersion: this.nodeVersion,
       npmDistTag: options.npmDistTag,
+      npmTrustedPublishing: options.npmTrustedPublishing,
+      environment: options.releaseEnvironment,
       releasableCommits: options.releasableCommits,
       nextVersionCommand: options.nextVersionCommand,
       versionBranchOptions: {
@@ -237,7 +239,7 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
       options.parent.requestInstallDependencies({ resolveDepsAndWritePackageJson: () => originalResolve.apply(this.package) });
     };
     /* @ts-ignore access private method */
-    this.package.resolveDepsAndWritePackageJson = () => {};
+    this.package.resolveDepsAndWritePackageJson = () => { };
 
     // Private package
     if (options.private) {
@@ -260,7 +262,7 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
    * I don't know why `tsconfig.dev.json` doesn't have an outdir, or where it's used,
    * but it's causing in-place `.js` files to appear.
    */
-  protected addTsconfigDevFix () {
+  protected addTsconfigDevFix() {
     this.tsconfigDev.file.addOverride('compilerOptions.outDir', 'lib');
   }
 

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -270,6 +270,29 @@ describe('CdkLabsMonorepo', () => {
       }));
     });
 
+    test('npmTrustedPublishing and releaseEnvironment are respected', () => {
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/one',
+        npmTrustedPublishing: true,
+        releaseEnvironment: 'release',
+      });
+
+      const outdir = Testing.synth(parent);
+      const releaseWorkflow = YAML.parse(outdir['.github/workflows/release.yml']);
+
+      expect(releaseWorkflow.jobs['cdklabs-one_release_npm'].environment).toStrictEqual('release');
+
+      // this also ensures the npm token doens't exist
+      expect(releaseWorkflow.jobs['cdklabs-one_release_npm'].steps[3].env).toStrictEqual({
+        NPM_CONFIG_PROVENANCE: 'true',
+        NPM_DIST_TAG: 'latest',
+        NPM_REGISTRY: 'registry.npmjs.org',
+        NPM_TRUSTED_PUBLISHER: 'true',
+      });
+
+    });
+
     test('npmDistTag works', () => {
       new yarn.TypeScriptWorkspace({
         parent,


### PR DESCRIPTION
In such projects, `release` is disabled because it is controlled by the monorepo parent project. This means the `npmTrustedPublishers` and `releaseEnvironment` properties are ignored, because they are only relevant for releasable projects. 

In our monorepo setup, release is controlled through other means, so we need to pass these properties over there.