### PR TITLE
fix(yarn): workspace commands fail because they are not run in topo order

### DIFF
--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -50,7 +50,7 @@ export class MonorepoRelease extends Component {
     this.github = gh;
     this.releaseTrigger = options.releaseTrigger ?? projenRelease.ReleaseTrigger.continuous();
     this.buildWithNx = options.buildWithNx ?? false;
-    this.wsRun = options.yarnBerry ? 'yarn workspaces foreach --all --exclude . run' : 'yarn workspaces run';
+    this.wsRun = options.yarnBerry ? 'yarn workspaces foreach --all --exclude . --topological run' : 'yarn workspaces run';
   }
 
   public workspaceRelease(project: TypeScriptWorkspace) {

--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -50,7 +50,7 @@ export class MonorepoRelease extends Component {
     this.github = gh;
     this.releaseTrigger = options.releaseTrigger ?? projenRelease.ReleaseTrigger.continuous();
     this.buildWithNx = options.buildWithNx ?? false;
-    this.wsRun = options.yarnBerry ? 'yarn workspaces foreach --all --exclude . --topological run' : 'yarn workspaces run';
+    this.wsRun = options.yarnBerry ? 'yarn workspaces foreach --all --exclude . --topological-dev run' : 'yarn workspaces run';
   }
 
   public workspaceRelease(project: TypeScriptWorkspace) {

--- a/src/yarn/monorepo.ts
+++ b/src/yarn/monorepo.ts
@@ -139,7 +139,7 @@ export class Monorepo extends typescript.TypeScriptProject {
     if (fmtTask) {
       buildTask.spawn(fmtTask);
     }
-    const wsRun = options.yarnBerry ? 'yarn workspaces foreach --all --exclude . run' : 'yarn workspaces run';
+    const wsRun = options.yarnBerry ? 'yarn workspaces foreach --all --exclude . --topological run' : 'yarn workspaces run';
 
     if (buildWithNx) {
       buildTask.exec('nx run-many -t build');

--- a/src/yarn/monorepo.ts
+++ b/src/yarn/monorepo.ts
@@ -139,7 +139,7 @@ export class Monorepo extends typescript.TypeScriptProject {
     if (fmtTask) {
       buildTask.spawn(fmtTask);
     }
-    const wsRun = options.yarnBerry ? 'yarn workspaces foreach --all --exclude . --topological run' : 'yarn workspaces run';
+    const wsRun = options.yarnBerry ? 'yarn workspaces foreach --all --exclude . --topological-dev run' : 'yarn workspaces run';
 
     if (buildWithNx) {
       buildTask.exec('nx run-many -t build');

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -704,6 +704,25 @@ describe('CdkLabsMonorepo', () => {
         '@swc/core': { built: true },
       });
     });
+
+    test('workspace commands run in topological order', () => {
+      const parent = new yarn.CdkLabsMonorepo({
+        name: 'monorepo',
+        defaultReleaseBranch: 'main',
+        yarnBerry: true,
+      });
+
+      const outdir = Testing.synth(parent);
+      const tasks = outdir['.projen/tasks.json'].tasks;
+
+      // Every task step that uses `yarn workspaces foreach` must include `--topological`
+      const allSteps = Object.values(tasks).flatMap((t: any) => t.steps ?? []);
+      const foreachSteps = allSteps.filter((s: any) => s.exec?.includes('yarn workspaces foreach'));
+      expect(foreachSteps.length).toBeGreaterThan(0);
+      for (const step of foreachSteps) {
+        expect(step.exec).toContain('--topological');
+      }
+    });
   });
 });
 

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -705,7 +705,7 @@ describe('CdkLabsMonorepo', () => {
       });
     });
 
-    test('workspace commands run in topological order', () => {
+    test('workspace commands run in topological order including devDependencies', () => {
       const parent = new yarn.CdkLabsMonorepo({
         name: 'monorepo',
         defaultReleaseBranch: 'main',
@@ -715,12 +715,12 @@ describe('CdkLabsMonorepo', () => {
       const outdir = Testing.synth(parent);
       const tasks = outdir['.projen/tasks.json'].tasks;
 
-      // Every task step that uses `yarn workspaces foreach` must include `--topological`
+      // Every task step that uses `yarn workspaces foreach` must include `--topological-dev`
       const allSteps = Object.values(tasks).flatMap((t: any) => t.steps ?? []);
       const foreachSteps = allSteps.filter((s: any) => s.exec?.includes('yarn workspaces foreach'));
       expect(foreachSteps.length).toBeGreaterThan(0);
       for (const step of foreachSteps) {
-        expect(step.exec).toContain('--topological');
+        expect(step.exec).toContain('--topological-dev');
       }
     });
   });


### PR DESCRIPTION
Without `--topological-dev`, `yarn workspaces foreach` runs workspaces in an arbitrary order. When workspaces depend on each other, this can break builds because a dependency hasn't been built yet when a downstream workspace tries to compile against it.

Using `--topological-dev` instead of `--topological` ensures devDependencies are also considered for ordering, which is needed when a workspace has build-time dependencies declared as devDependencies.

Fixes #
