### PR TITLE
fix(yarn): release workflow missing corepack enable for yarn berry

### DIFF
--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -251,18 +251,7 @@ export class MonorepoRelease extends Component {
 
     // The arrays are being cloned to avoid accumulating values from previous branches
     const preBuildSteps = [
-      {
-        name: 'Setup Node.js',
-        uses: 'actions/setup-node@v6',
-        with: {
-          'node-version': (this.project as any).nodeVersion ?? 'lts/*',
-          'package-manager-cache': false,
-        },
-      },
-      {
-        name: 'Install dependencies',
-        run: this.options.yarnBerry ? 'yarn install --immutable' : 'yarn install --check-files --frozen-lockfile',
-      },
+      ...(this.project as any).renderWorkflowSetup({ mutable: false }),
       ...(this.options.releaseWorkflowSetupSteps ?? []),
     ];
     const postBuildSteps = [...(this.options.postBuildSteps ?? [])];

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -1,5 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CdkLabsMonorepo Yarn Berry release workflow setup steps for yarn berry 1`] = `
+[
+  {
+    "name": "Checkout",
+    "uses": "actions/checkout@v6",
+    "with": {
+      "fetch-depth": 0,
+    },
+  },
+  {
+    "name": "Set git identity",
+    "run": "git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"",
+  },
+  {
+    "name": "Enable corepack",
+    "run": "corepack enable",
+  },
+  {
+    "name": "Setup Node.js",
+    "uses": "actions/setup-node@v6",
+    "with": {
+      "node-version": "lts/*",
+      "package-manager-cache": false,
+    },
+  },
+  {
+    "name": "Install dependencies",
+    "run": "yarn install --immutable",
+  },
+  {
+    "name": "release",
+    "run": "npx projen release",
+  },
+  {
+    "id": "check-publish-cdklabs-one",
+    "run": "(git ls-remote -q --exit-code --tags origin $(cat dist/releasetag.txt) && (echo "publish=false" >> $GITHUB_OUTPUT)) || echo "publish=true" >> $GITHUB_OUTPUT",
+    "working-directory": "packages/@cdklabs/one",
+  },
+  {
+    "id": "git_remote",
+    "name": "Check for new commits",
+    "run": "echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT",
+  },
+  {
+    "continue-on-error": true,
+    "if": "\${{ steps.git_remote.outputs.latest_commit == github.sha }}",
+    "name": "@cdklabs/one: Backup artifact permissions",
+    "run": "cd dist && getfacl -R . > permissions-backup.acl",
+    "working-directory": "packages/@cdklabs/one",
+  },
+  {
+    "if": "\${{ steps.git_remote.outputs.latest_commit == github.sha }}",
+    "name": "@cdklabs/one: Upload artifact",
+    "uses": "actions/upload-artifact@v7",
+    "with": {
+      "name": "cdklabs-one_build-artifact",
+      "overwrite": true,
+      "path": "packages/@cdklabs/one/dist",
+    },
+  },
+]
+`;
+
 exports[`CdkLabsMonorepo nx integration can build with nx 1`] = `
 {
   "name": "build",
@@ -5471,6 +5535,66 @@ tsconfig.tsbuildinfo
     ],
   },
 }
+`;
+
+exports[`CdkLabsMonorepo with monorepo that releases release workflow setup steps for yarn classic 1`] = `
+[
+  {
+    "name": "Checkout",
+    "uses": "actions/checkout@v6",
+    "with": {
+      "fetch-depth": 0,
+    },
+  },
+  {
+    "name": "Set git identity",
+    "run": "git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"",
+  },
+  {
+    "name": "Setup Node.js",
+    "uses": "actions/setup-node@v6",
+    "with": {
+      "node-version": "lts/*",
+      "package-manager-cache": false,
+    },
+  },
+  {
+    "name": "Install dependencies",
+    "run": "yarn install --check-files --frozen-lockfile",
+  },
+  {
+    "name": "release",
+    "run": "npx projen release",
+  },
+  {
+    "id": "check-publish-cdklabs-one",
+    "run": "(git ls-remote -q --exit-code --tags origin $(cat dist/releasetag.txt) && (echo "publish=false" >> $GITHUB_OUTPUT)) || echo "publish=true" >> $GITHUB_OUTPUT",
+    "working-directory": "packages/@cdklabs/one",
+  },
+  {
+    "id": "git_remote",
+    "name": "Check for new commits",
+    "run": "echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT",
+  },
+  {
+    "continue-on-error": true,
+    "if": "\${{ steps.git_remote.outputs.latest_commit == github.sha }}",
+    "name": "@cdklabs/one: Backup artifact permissions",
+    "run": "cd dist && getfacl -R . > permissions-backup.acl",
+    "working-directory": "packages/@cdklabs/one",
+  },
+  {
+    "if": "\${{ steps.git_remote.outputs.latest_commit == github.sha }}",
+    "name": "@cdklabs/one: Upload artifact",
+    "uses": "actions/upload-artifact@v7",
+    "with": {
+      "name": "cdklabs-one_build-artifact",
+      "overwrite": true,
+      "path": "packages/@cdklabs/one/dist",
+    },
+  },
+]
 `;
 
 exports[`CdkLabsMonorepo workspace inherits config from monorepo repository configuration 1`] = `

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -322,6 +322,18 @@ describe('CdkLabsMonorepo', () => {
       expect(outdir).toMatchSnapshot();
     });
 
+    test('release workflow setup steps for yarn classic', () => {
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/one',
+      });
+
+      const outdir = Testing.synth(parent);
+      const releaseWorkflow = YAML.parse(outdir['.github/workflows/release.yml']);
+
+      expect(releaseWorkflow.jobs.release.steps).toMatchSnapshot();
+    });
+
     test('monorepo release with nextVersionCommand', () => {
       new yarn.TypeScriptWorkspace({
         parent,
@@ -722,6 +734,25 @@ describe('CdkLabsMonorepo', () => {
       for (const step of foreachSteps) {
         expect(step.exec).toContain('--topological-dev');
       }
+    });
+
+    test('release workflow setup steps for yarn berry', () => {
+      const parent = new yarn.CdkLabsMonorepo({
+        name: 'monorepo',
+        defaultReleaseBranch: 'main',
+        yarnBerry: true,
+        release: true,
+      });
+
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/one',
+      });
+
+      const outdir = Testing.synth(parent);
+      const releaseWorkflow = YAML.parse(outdir['.github/workflows/release.yml']);
+
+      expect(releaseWorkflow.jobs.release.steps).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
Fixes #

The release workflow generated by `MonorepoRelease.createPublishWorkflow()` was hand-rolling the `Setup Node.js` and `Install dependencies` steps instead of using projen's `NodeProject.renderWorkflowSetup()`. This meant the `corepack enable` step required for Yarn Berry was never included, causing the release workflow to fail with:

```
Run yarn install --immutable
error This project's package.json defines "packageManager": "yarn@4.13.0".
However the current global version of Yarn is 1.22.22.
```

The build workflow already had the correct steps because projen core generates them via `renderWorkflowSetup()`. This change makes the release workflow use the same method, so any package manager setup (corepack, pnpm, bun) is handled consistently and automatically going forward.
