### PR TITLE
feat(upgrades): default 3-day cooldown for non-yarn_classic package managers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
+      - name: Enable corepack
+        run: corepack enable
       - name: Install Dependencies
         run: cd .repo && yarn install --immutable
       - name: Extract build artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,14 +110,14 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
-      - name: Enable corepack
-        run: corepack enable
       - name: Install Dependencies
         run: cd .repo && yarn install --immutable
       - name: Extract build artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,8 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -273,11 +273,12 @@
       "description": "upgrade dependencies",
       "env": {
         "CI": "0",
-        "YARN_ENABLE_IMMUTABLE_INSTALLS": "false"
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "false",
+        "YARN_NPM_MINIMAL_AGE_GATE": "4320"
       },
       "steps": [
         {
-          "exec": "yarn dlx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=prod --filter=yaml"
+          "exec": "yarn dlx npm-check-updates@18 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=prod --filter=yaml"
         },
         {
           "exec": "yarn install --no-immutable"
@@ -298,11 +299,12 @@
       "description": "upgrade dev dependencies",
       "env": {
         "CI": "0",
-        "YARN_ENABLE_IMMUTABLE_INSTALLS": "false"
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "false",
+        "YARN_NPM_MINIMAL_AGE_GATE": "4320"
       },
       "steps": [
         {
-          "exec": "yarn dlx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@jsii/spec,@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,jsii-reflect,projen,ts-jest,ts-node"
+          "exec": "yarn dlx npm-check-updates@18 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=dev --filter=@jsii/spec,@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,jsii-reflect,projen,ts-jest,ts-node"
         },
         {
           "exec": "yarn install --no-immutable"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -278,7 +278,7 @@
       },
       "steps": [
         {
-          "exec": "yarn dlx npm-check-updates@18 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=prod --filter=yaml"
+          "exec": "yarn dlx npm-check-updates@20 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=prod --filter=yaml"
         },
         {
           "exec": "yarn install --no-immutable"
@@ -304,7 +304,7 @@
       },
       "steps": [
         {
-          "exec": "yarn dlx npm-check-updates@18 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=dev --filter=@jsii/spec,@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,jsii-reflect,projen,ts-jest,ts-node"
+          "exec": "yarn dlx npm-check-updates@20 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=dev --filter=@jsii/spec,@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,jsii-reflect,projen,ts-jest,ts-node"
         },
         {
           "exec": "yarn install --no-immutable"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,4 @@
-import { javascript } from 'projen';
+import { javascript, JsonPatch } from 'projen';
 import { generateCdkCommonOptions } from './projenrc/cdk-common-options';
 import { generateCdkConstructLibraryOptions } from './projenrc/cdk-construct-library-options';
 import { generateCdkJsiiOptions } from './projenrc/cdk-jsii-options';
@@ -40,5 +40,10 @@ generateCdkJsiiOptions(project);
 
 // that is this package!
 project.deps.removeDependency(project.name);
+
+// Workaround: projen doesn't add corepack enable to package-js job for Yarn Berry
+project.github?.tryFindWorkflow('build')?.file?.patch(
+  JsonPatch.add('/jobs/package-js/steps/4', { name: 'Enable corepack', run: 'corepack enable' }),
+);
 
 project.synth();

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,4 @@
-import { javascript, JsonPatch } from 'projen';
+import { javascript } from 'projen';
 import { generateCdkCommonOptions } from './projenrc/cdk-common-options';
 import { generateCdkConstructLibraryOptions } from './projenrc/cdk-construct-library-options';
 import { generateCdkJsiiOptions } from './projenrc/cdk-jsii-options';
@@ -40,10 +40,5 @@ generateCdkJsiiOptions(project);
 
 // that is this package!
 project.deps.removeDependency(project.name);
-
-// Workaround: projen doesn't add corepack enable to package-js job for Yarn Berry
-project.github?.tryFindWorkflow('build')?.file?.patch(
-  JsonPatch.add('/jobs/package-js/steps/4', { name: 'Enable corepack', run: 'corepack enable' }),
-);
 
 project.synth();

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jsii-pacmak": "^1.127.0",
     "jsii-reflect": "^1.127.0",
     "jsii-rosetta": "~5.9",
-    "projen": "^0.99.34",
+    "projen": "^0.99.45",
     "ts-jest": "^29",
     "ts-node": "^10.9.2",
     "typescript": "~5.9"

--- a/src/common-options.ts
+++ b/src/common-options.ts
@@ -100,6 +100,9 @@ export function configureCommonComponents(project: typescript.TypeScriptProject,
     const exclude = opts.upgradeCdklabsProjenProjectTypes ? UpgradeCdklabsProjenProjectTypes.deps : [];
     const labels = opts.autoApproveUpgrades ? [opts.autoApproveOptions?.label ?? 'auto-approve'] : [];
 
+    // Default cooldown of 3 days for non-yarn_classic package managers
+    const cooldown = project.package.packageManager !== javascript.NodePackageManager.YARN_CLASSIC ? 3 : undefined;
+
     // Get branch configuration from depsUpgradeOptions if available
     const workflowOptions = (cron: string) => ({
       labels,
@@ -109,6 +112,7 @@ export function configureCommonComponents(project: typescript.TypeScriptProject,
 
     new javascript.UpgradeDependencies(project, {
       taskName: 'upgrade',
+      cooldown,
       // NOTE: we explicitly do NOT upgrade PEER dependencies. We want the widest range of compatibility possible,
       // and by bumping peer dependencies we force the customer to also unnecessarily upgrade, which they may not want
       // to do. Never mind that peerDependencies are usually also devDependencies, so it doesn't make sense to upgrade
@@ -125,6 +129,7 @@ export function configureCommonComponents(project: typescript.TypeScriptProject,
       types: [DependencyType.BUILD, DependencyType.DEVENV, DependencyType.TEST],
       exclude,
       semanticCommit: 'chore',
+      cooldown,
       pullRequestTitle: 'upgrade dev dependencies',
       // Run at 22:00Z every Monday, this is deliberately after prod updates to avoid conflicts
       workflowOptions: workflowOptions('0 22 * * 1'),

--- a/src/upgrade-cdklabs-projen-project-types.ts
+++ b/src/upgrade-cdklabs-projen-project-types.ts
@@ -21,6 +21,7 @@ export class UpgradeCdklabsProjenProjectTypes extends Component {
 
     const upgrade = new javascript.UpgradeDependencies(project, {
       taskName,
+      cooldown: undefined, // Always update without delay
       target: 'latest',
       pullRequestTitle: 'upgrade cdklabs-projen-project-types',
       include: UpgradeCdklabsProjenProjectTypes.deps,

--- a/src/yarn/monorepo.ts
+++ b/src/yarn/monorepo.ts
@@ -160,8 +160,8 @@ export class Monorepo extends typescript.TypeScriptProject {
     });
 
     // Upgrade all packages
-    const cooldown = options.depsUpgradeOptions?.cooldown;
-    const upgradeEnv: Record<string, string> = { CI: '0' };
+    const cooldown = options.depsUpgradeOptions?.cooldown ?? (options.yarnBerry ? 3 : undefined);
+    const upgradeEnv = { ...this.upgradeWorkflow?.upgradeTask.envVars || {} };
     if (cooldown && options.yarnBerry) {
       upgradeEnv.YARN_NPM_MINIMAL_AGE_GATE = String(cooldown * 24 * 60);
     }

--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -215,7 +215,7 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
       this.tasks.removeTask(upgrades.upgradeTask.name);
       this.tasks.removeTask(upgrades.postUpgradeTask.name);
       this.tasks.addTask('check-for-updates', {
-        env: { CI: '0' },
+        env: { ...upgrades.upgradeTask.envVars },
         steps: {
           toJSON: () => {
             const steps = (upgrades as any).renderTaskSteps() as TaskStep[];

--- a/test/__snapshots__/cdk.test.ts.snap
+++ b/test/__snapshots__/cdk.test.ts.snap
@@ -1411,7 +1411,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@20 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           {
             "exec": "yarn install --check-files",
@@ -1435,7 +1435,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-dev-deps",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,jsii-rosetta,ts-jest,typescript",
+            "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,jsii-rosetta,ts-jest,typescript",
           },
           {
             "exec": "yarn install --check-files",
@@ -3223,7 +3223,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@20 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           {
             "exec": "yarn install --check-files",
@@ -3247,7 +3247,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-dev-deps",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,ts-jest,typescript",
+            "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,ts-jest,typescript",
           },
           {
             "exec": "yarn install --check-files",
@@ -4854,7 +4854,7 @@ junit.xml
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@20 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           {
             "exec": "yarn install --check-files",
@@ -4878,7 +4878,7 @@ junit.xml
         "name": "upgrade-dev-deps",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,ts-jest,typescript",
+            "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,ts-jest,typescript",
           },
           {
             "exec": "yarn install --check-files",

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -1310,7 +1310,7 @@ tsconfig.tsbuildinfo
         "name": "check-for-updates",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
+            "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
           },
         ],
       },
@@ -2129,7 +2129,7 @@ tsconfig.tsbuildinfo
         "name": "check-for-updates",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
+            "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
           },
         ],
       },
@@ -4065,7 +4065,7 @@ tsconfig.tsbuildinfo
         "name": "check-for-updates",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
+            "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
           },
         ],
       },
@@ -4957,7 +4957,7 @@ tsconfig.tsbuildinfo
         "name": "check-for-updates",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
+            "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
           },
         ],
       },
@@ -6757,7 +6757,7 @@ tsconfig.tsbuildinfo
         "name": "check-for-updates",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
+            "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,prettier,ts-jest,typescript",
           },
         ],
       },

--- a/test/__snapshots__/cdklabs.test.ts.snap
+++ b/test/__snapshots__/cdklabs.test.ts.snap
@@ -1801,7 +1801,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@20 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           {
             "exec": "yarn install --check-files",
@@ -1825,7 +1825,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-dev-deps",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,jsii-rosetta,ts-jest,typescript",
+            "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,jsii-rosetta,ts-jest,typescript",
           },
           {
             "exec": "yarn install --check-files",
@@ -4119,7 +4119,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@20 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           {
             "exec": "yarn install --check-files",
@@ -4143,7 +4143,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-dev-deps",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,ts-jest,typescript",
+            "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,ts-jest,typescript",
           },
           {
             "exec": "yarn install --check-files",
@@ -5780,7 +5780,7 @@ junit.xml
         "name": "upgrade-cdklabs-projen-project-types",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
+            "exec": "npx npm-check-updates@20 --upgrade --target=latest --peer --no-deprecated --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen",
           },
           {
             "exec": "yarn install --check-files",
@@ -5804,7 +5804,7 @@ junit.xml
         "name": "upgrade-dev-deps",
         "steps": [
           {
-            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,ts-jest,typescript",
+            "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev --filter=@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,ts-jest,typescript",
           },
           {
             "exec": "yarn install --check-files",

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -527,6 +527,54 @@ describe('CdkLabsMonorepo', () => {
   });
 
   describe('monorepo dependency upgrades', () => {
+    test('no cooldown for yarn classic monorepo', () => {
+      const parent = new yarn.CdkLabsMonorepo({
+        name: 'monorepo',
+        defaultReleaseBranch: 'main',
+      });
+
+      new yarn.TypeScriptWorkspace({ parent, name: '@cdklabs/one' });
+
+      const outdir = Testing.synth(parent);
+      const tasks = outdir['.projen/tasks.json'].tasks;
+
+      expect(tasks.upgrade.steps[0].exec).not.toContain('--cooldown');
+      expect(tasks.upgrade.env.YARN_NPM_MINIMAL_AGE_GATE).toBeUndefined();
+    });
+
+    test('3 day cooldown for yarn berry monorepo', () => {
+      const parent = new yarn.CdkLabsMonorepo({
+        name: 'monorepo',
+        defaultReleaseBranch: 'main',
+        yarnBerry: true,
+      });
+
+      new yarn.TypeScriptWorkspace({ parent, name: '@cdklabs/one' });
+
+      const outdir = Testing.synth(parent);
+      const tasks = outdir['.projen/tasks.json'].tasks;
+
+      expect(tasks.upgrade.steps[0].exec).toContain('--cooldown=3');
+      expect(tasks.upgrade.env.YARN_NPM_MINIMAL_AGE_GATE).toBe('4320');
+    });
+
+    test('workspace check-for-updates inherits cooldown env from yarn berry monorepo', () => {
+      const parent = new yarn.CdkLabsMonorepo({
+        name: 'monorepo',
+        defaultReleaseBranch: 'main',
+        yarnBerry: true,
+      });
+
+      new yarn.TypeScriptWorkspace({ parent, name: '@cdklabs/one' });
+
+      const outdir = Testing.synth(parent);
+      const wsTasks = outdir['packages/@cdklabs/one/.projen/tasks.json'].tasks;
+
+      // The env vars from the workspace's UpgradeDependencies are propagated
+      expect(wsTasks['check-for-updates'].env).toBeDefined();
+      expect(wsTasks['check-for-updates'].env.CI).toBe('0');
+    });
+
     test('workspaces get a check-for-updates task, but not upgrades', () => {
       const parent = new yarn.CdkLabsMonorepo({
         name: 'monorepo',

--- a/test/cdklabs.test.ts
+++ b/test/cdklabs.test.ts
@@ -1,4 +1,4 @@
-import { Testing } from 'projen';
+import { Testing, javascript } from 'projen';
 import { Stability } from 'projen/lib/cdk';
 import * as YAML from 'yaml';
 import { CdklabsConstructLibrary, CdklabsConstructLibraryOptions, CdklabsJsiiProject, CdklabsJsiiProjectOptions, CdklabsTypeScriptProject, CdklabsTypeScriptProjectOptions, JsiiLanguage } from '../src/cdklabs';
@@ -451,6 +451,39 @@ describe('CdklabsJsiiProject', () => {
       expect(releaseWorkflow).toContain('PYPI_TRUSTED_PUBLISHER: "true"');
       expect(releaseWorkflow).toContain('NUGET_TRUSTED_PUBLISHER: "true"');
     });
+  });
+});
+
+describe('upgrade dependency cooldown', () => {
+  test('no cooldown for yarn classic (default)', () => {
+    const project = new TestCdkLabsConstructLibrary();
+    const outdir = Testing.synth(project);
+    const tasks = outdir['.projen/tasks.json'].tasks;
+
+    expect(tasks.upgrade.steps[0].exec).not.toContain('--cooldown');
+    expect(tasks['upgrade-dev-deps'].steps[0].exec).not.toContain('--cooldown');
+  });
+
+  test('3 day cooldown for non-yarn_classic package managers', () => {
+    const project = new TestCdkLabsTypeScriptProject({
+      packageManager: javascript.NodePackageManager.YARN_BERRY,
+      deps: ['some-dep'],
+    });
+    const outdir = Testing.synth(project);
+    const tasks = outdir['.projen/tasks.json'].tasks;
+
+    expect(tasks.upgrade.steps[0].exec).toContain('--cooldown=3');
+    expect(tasks['upgrade-dev-deps'].steps[0].exec).toContain('--cooldown=3');
+  });
+
+  test('upgrade-cdklabs-projen-project-types never has cooldown', () => {
+    const project = new TestCdkLabsTypeScriptProject({
+      packageManager: javascript.NodePackageManager.YARN_BERRY,
+    });
+    const outdir = Testing.synth(project);
+    const tasks = outdir['.projen/tasks.json'].tasks;
+
+    expect(tasks['upgrade-cdklabs-projen-project-types'].steps[0].exec).not.toContain('--cooldown');
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,7 +2073,7 @@ __metadata:
     jsii-pacmak: "npm:^1.127.0"
     jsii-reflect: "npm:^1.127.0"
     jsii-rosetta: "npm:~5.9"
-    projen: "npm:^0.99.34"
+    projen: "npm:^0.99.45"
     ts-jest: "npm:^29"
     ts-node: "npm:^10.9.2"
     typescript: "npm:~5.9"
@@ -6109,9 +6109,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"projen@npm:^0.99.34":
-  version: 0.99.44
-  resolution: "projen@npm:0.99.44"
+"projen@npm:^0.99.45":
+  version: 0.99.45
+  resolution: "projen@npm:0.99.45"
   dependencies:
     "@iarna/toml": "npm:^2.2.5"
     case: "npm:^1.6.3"
@@ -6132,7 +6132,7 @@ __metadata:
     constructs: ^10.0.0
   bin:
     projen: bin/projen
-  checksum: 10c0/822301e6930a180cde19f7f167bb6d8120983642b355a596b51e0e11428bf9a58e6b8ebaa2662aedf2f473cc15cd851327f8efd2e4df86d10579d18c3e3ff8c2
+  checksum: 10c0/8f674794d77df4a3c3ecdaf993531d72243a19b030dc600da6b89a14c658397189aba0dc4c1f24a684d75e3d664231f32d8165f275baac453796100bdc91e7b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #

When the package manager is not `yarn_classic`, dependency upgrade tasks now default to a 3-day cooldown period. This prevents upgrading to versions that were published very recently, reducing the risk of picking up broken or yanked releases.

The cooldown applies across all project types: `CdklabsConstructLibrary`, `CdklabsTypeScriptProject`, `CdklabsJsiiProject`, and the `CdkLabsMonorepo` (when using Yarn Berry). For Yarn Berry monorepos, the cooldown is also enforced at the Yarn level via `YARN_NPM_MINIMAL_AGE_GATE`.

The `upgrade-cdklabs-projen-project-types` workflow is explicitly excluded from the cooldown and always updates without delay, so projen project type updates can propagate immediately.

Workspace `check-for-updates` tasks now inherit environment variables from the `UpgradeDependencies` component instead of hardcoding them, ensuring consistency with the monorepo's upgrade configuration.
