### PR TITLE
fix(yarn): workspace check-for-updates missing cooldown default

### DIFF
--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -126,6 +126,7 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
       depsUpgrade: options.depsUpgrade ?? true,
       depsUpgradeOptions: {
         workflow: false,
+        cooldown: options.parent.options.depsUpgradeOptions?.cooldown ?? (options.parent.options.yarnBerry ? 3 : undefined),
         exclude: [
           ...(options.excludeDepsFromUpgrade ?? []),
           ...(packageNames(options.deps?.filter(isWorkspaceReference)) ?? []),

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -573,6 +573,10 @@ describe('CdkLabsMonorepo', () => {
       // The env vars from the workspace's UpgradeDependencies are propagated
       expect(wsTasks['check-for-updates'].env).toBeDefined();
       expect(wsTasks['check-for-updates'].env.CI).toBe('0');
+
+      // The cooldown flag is included in the check-for-updates steps
+      const ncuStep = wsTasks['check-for-updates'].steps.find((s: any) => s.exec?.includes('npm-check-updates'));
+      expect(ncuStep.exec).toContain('--cooldown=3');
     });
 
     test('workspaces get a check-for-updates task, but not upgrades', () => {


### PR DESCRIPTION
The recently added default upgrade cooldown for non-yarn_classic package managers (#916) was not being propagated to `TypeScriptWorkspace`s in a yarn berry monorepo. The workspace's `depsUpgradeOptions` were missing the `cooldown` property, so the `check-for-updates` task generated by `UpgradeDependencies` did not include the `--cooldown` flag in its `npm-check-updates` command.

This forwards the monorepo's cooldown setting into each workspace's `depsUpgradeOptions`, using the same defaulting logic: use an explicit value if provided, otherwise default to `3` for yarn berry monorepos.
