### PR TITLE
fix(yarn): suppress install logging for missing workspace node_modules

### DIFF
--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -245,9 +245,15 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
       receiveArgs: true,
     });
 
-    // Install dependencies via the parent project
+    // We handle dependencies via the parent project
+
+    // Disable workspace resolveDepsAndWritePackageJson
     /* @ts-ignore access private method */
     const originalResolve = this.package.resolveDepsAndWritePackageJson;
+    /* @ts-ignore access private method */
+    this.package.resolveDepsAndWritePackageJson = () => [];
+
+    // Instead of installing dependencies, request from the parent
     /* @ts-ignore access private method */
     this.package.installDependencies = (trigger: javascript.InstallTrigger) => {
       if (trigger.reason === javascript.InstallReason.NO_NODE_MODULES) {
@@ -256,8 +262,18 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
       }
       options.parent.requestInstallDependencies({ resolveDepsAndWritePackageJson: () => originalResolve.apply(this.package) });
     };
+
+    // Fix the install trigger logging to match actual requests
     /* @ts-ignore access private method */
-    this.package.resolveDepsAndWritePackageJson = () => [];
+    const originalLogTrigger = this.package.logInstallTrigger;
+    /* @ts-ignore access private method */
+    this.package.logInstallTrigger = (trigger: InstallTrigger) => {
+      if (trigger.reason === javascript.InstallReason.NO_NODE_MODULES) {
+        return;
+      }
+      /* @ts-ignore access private method */
+      return originalLogTrigger.apply(this.package, [trigger]);
+    };
 
     // Private package
     if (options.private) {


### PR DESCRIPTION
Follow-up to #918. Improves the workspace install trigger handling in two ways.

The `logInstallTrigger` is now also suppressed for `NO_NODE_MODULES` in workspaces, so users don't see a misleading "Installing dependencies..." message for a workspace that simply doesn't have its own `node_modules` due to hoisting.

The code is also reorganized for clarity: `resolveDepsAndWritePackageJson` is disabled first, then `installDependencies` is overridden, and finally `logInstallTrigger` is patched — matching the order they are called in projen's `postSynthesize`.

Fixes #
