### PR TITLE
chore: make InstallReason usage compatible with projen <0.99.48

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -20,9 +20,6 @@ const project = new CdklabsJsiiProject({
   enablePRAutoMerge: true,
   upgradeCdklabsProjenProjectTypes: false, // that is this project!
   setNodeEngineVersion: false,
-  peerDependencyOptions: {
-    pinnedDevDependency: false,
-  },
   jsiiVersion: '~5.9',
   typescriptVersion: '~5.9',
 

--- a/API.md
+++ b/API.md
@@ -31,7 +31,6 @@ new CdkConstructLibrary(options: CdkConstructLibraryOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.CdkConstructLibrary.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.CdkConstructLibrary.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.CdkConstructLibrary.addExcludeFromCleanup">addExcludeFromCleanup</a></code> | Exclude the matching files from pre-synth cleanup. |
 | <code><a href="#cdklabs-projen-project-types.CdkConstructLibrary.addGitIgnore">addGitIgnore</a></code> | Adds a .gitignore pattern. |
 | <code><a href="#cdklabs-projen-project-types.CdkConstructLibrary.addPackageIgnore">addPackageIgnore</a></code> | Adds patterns to be ignored by npm. |
@@ -73,27 +72,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.CdkConstructLibrary.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.CdkConstructLibrary.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `addExcludeFromCleanup` <a name="addExcludeFromCleanup" id="cdklabs-projen-project-types.CdkConstructLibrary.addExcludeFromCleanup"></a>
 
@@ -648,7 +626,7 @@ names of cdk modules (e.g. `@aws-cdk/aws-lambda`).
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.CdkConstructLibrary.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.CdkConstructLibrary.isConstruct"></a>
 
 ```typescript
 import { CdkConstructLibrary } from 'cdklabs-projen-project-types'
@@ -657,20 +635,6 @@ CdkConstructLibrary.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.CdkConstructLibrary.isConstruct.parameter.x"></a>
 
@@ -1655,7 +1619,6 @@ new CdkJsiiProject(options: CdkJsiiProjectOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.CdkJsiiProject.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.CdkJsiiProject.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.CdkJsiiProject.addExcludeFromCleanup">addExcludeFromCleanup</a></code> | Exclude the matching files from pre-synth cleanup. |
 | <code><a href="#cdklabs-projen-project-types.CdkJsiiProject.addGitIgnore">addGitIgnore</a></code> | Adds a .gitignore pattern. |
 | <code><a href="#cdklabs-projen-project-types.CdkJsiiProject.addPackageIgnore">addPackageIgnore</a></code> | Adds patterns to be ignored by npm. |
@@ -1695,27 +1658,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.CdkJsiiProject.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.CdkJsiiProject.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `addExcludeFromCleanup` <a name="addExcludeFromCleanup" id="cdklabs-projen-project-types.CdkJsiiProject.addExcludeFromCleanup"></a>
 
@@ -2236,7 +2178,7 @@ The command to execute.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.CdkJsiiProject.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.CdkJsiiProject.isConstruct"></a>
 
 ```typescript
 import { CdkJsiiProject } from 'cdklabs-projen-project-types'
@@ -2245,20 +2187,6 @@ CdkJsiiProject.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.CdkJsiiProject.isConstruct.parameter.x"></a>
 
@@ -3206,7 +3134,6 @@ new CdklabsConstructLibrary(options: CdklabsConstructLibraryOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibrary.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibrary.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibrary.addExcludeFromCleanup">addExcludeFromCleanup</a></code> | Exclude the matching files from pre-synth cleanup. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibrary.addGitIgnore">addGitIgnore</a></code> | Adds a .gitignore pattern. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsConstructLibrary.addPackageIgnore">addPackageIgnore</a></code> | Adds patterns to be ignored by npm. |
@@ -3248,27 +3175,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.CdklabsConstructLibrary.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.CdklabsConstructLibrary.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `addExcludeFromCleanup` <a name="addExcludeFromCleanup" id="cdklabs-projen-project-types.CdklabsConstructLibrary.addExcludeFromCleanup"></a>
 
@@ -3823,7 +3729,7 @@ names of cdk modules (e.g. `@aws-cdk/aws-lambda`).
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.CdklabsConstructLibrary.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.CdklabsConstructLibrary.isConstruct"></a>
 
 ```typescript
 import { CdklabsConstructLibrary } from 'cdklabs-projen-project-types'
@@ -3832,20 +3738,6 @@ CdklabsConstructLibrary.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.CdklabsConstructLibrary.isConstruct.parameter.x"></a>
 
@@ -4830,7 +4722,6 @@ new CdklabsJsiiProject(options: CdklabsJsiiProjectOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.CdklabsJsiiProject.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.CdklabsJsiiProject.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsJsiiProject.addExcludeFromCleanup">addExcludeFromCleanup</a></code> | Exclude the matching files from pre-synth cleanup. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsJsiiProject.addGitIgnore">addGitIgnore</a></code> | Adds a .gitignore pattern. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsJsiiProject.addPackageIgnore">addPackageIgnore</a></code> | Adds patterns to be ignored by npm. |
@@ -4870,27 +4761,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.CdklabsJsiiProject.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.CdklabsJsiiProject.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `addExcludeFromCleanup` <a name="addExcludeFromCleanup" id="cdklabs-projen-project-types.CdklabsJsiiProject.addExcludeFromCleanup"></a>
 
@@ -5411,7 +5281,7 @@ The command to execute.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.CdklabsJsiiProject.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.CdklabsJsiiProject.isConstruct"></a>
 
 ```typescript
 import { CdklabsJsiiProject } from 'cdklabs-projen-project-types'
@@ -5420,20 +5290,6 @@ CdklabsJsiiProject.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.CdklabsJsiiProject.isConstruct.parameter.x"></a>
 
@@ -6381,7 +6237,6 @@ new yarn.CdkLabsMonorepo(options: CdkLabsMonorepoOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.yarn.CdkLabsMonorepo.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.yarn.CdkLabsMonorepo.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.yarn.CdkLabsMonorepo.addExcludeFromCleanup">addExcludeFromCleanup</a></code> | Exclude the matching files from pre-synth cleanup. |
 | <code><a href="#cdklabs-projen-project-types.yarn.CdkLabsMonorepo.addGitIgnore">addGitIgnore</a></code> | Adds a .gitignore pattern. |
 | <code><a href="#cdklabs-projen-project-types.yarn.CdkLabsMonorepo.addPackageIgnore">addPackageIgnore</a></code> | Adds patterns to be ignored by npm. |
@@ -6422,27 +6277,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.yarn.CdkLabsMonorepo.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.yarn.CdkLabsMonorepo.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `addExcludeFromCleanup` <a name="addExcludeFromCleanup" id="cdklabs-projen-project-types.yarn.CdkLabsMonorepo.addExcludeFromCleanup"></a>
 
@@ -6978,7 +6812,7 @@ This is used to resolve dependency versions from `*` to a concrete version const
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.yarn.CdkLabsMonorepo.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.yarn.CdkLabsMonorepo.isConstruct"></a>
 
 ```typescript
 import { yarn } from 'cdklabs-projen-project-types'
@@ -6987,20 +6821,6 @@ yarn.CdkLabsMonorepo.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.yarn.CdkLabsMonorepo.isConstruct.parameter.x"></a>
 
@@ -7988,7 +7808,6 @@ new CdklabsTypeScriptProject(options: CdklabsTypeScriptProjectOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.CdklabsTypeScriptProject.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.CdklabsTypeScriptProject.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsTypeScriptProject.addExcludeFromCleanup">addExcludeFromCleanup</a></code> | Exclude the matching files from pre-synth cleanup. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsTypeScriptProject.addGitIgnore">addGitIgnore</a></code> | Adds a .gitignore pattern. |
 | <code><a href="#cdklabs-projen-project-types.CdklabsTypeScriptProject.addPackageIgnore">addPackageIgnore</a></code> | Adds patterns to be ignored by npm. |
@@ -8028,27 +7847,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.CdklabsTypeScriptProject.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.CdklabsTypeScriptProject.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `addExcludeFromCleanup` <a name="addExcludeFromCleanup" id="cdklabs-projen-project-types.CdklabsTypeScriptProject.addExcludeFromCleanup"></a>
 
@@ -8569,7 +8367,7 @@ The command to execute.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.CdklabsTypeScriptProject.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.CdklabsTypeScriptProject.isConstruct"></a>
 
 ```typescript
 import { CdklabsTypeScriptProject } from 'cdklabs-projen-project-types'
@@ -8578,20 +8376,6 @@ CdklabsTypeScriptProject.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.CdklabsTypeScriptProject.isConstruct.parameter.x"></a>
 
@@ -9539,7 +9323,6 @@ new CdkTypeScriptProject(options: CdkTypeScriptProjectOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.CdkTypeScriptProject.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.CdkTypeScriptProject.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.CdkTypeScriptProject.addExcludeFromCleanup">addExcludeFromCleanup</a></code> | Exclude the matching files from pre-synth cleanup. |
 | <code><a href="#cdklabs-projen-project-types.CdkTypeScriptProject.addGitIgnore">addGitIgnore</a></code> | Adds a .gitignore pattern. |
 | <code><a href="#cdklabs-projen-project-types.CdkTypeScriptProject.addPackageIgnore">addPackageIgnore</a></code> | Adds patterns to be ignored by npm. |
@@ -9579,27 +9362,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.CdkTypeScriptProject.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.CdkTypeScriptProject.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `addExcludeFromCleanup` <a name="addExcludeFromCleanup" id="cdklabs-projen-project-types.CdkTypeScriptProject.addExcludeFromCleanup"></a>
 
@@ -10120,7 +9882,7 @@ The command to execute.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.CdkTypeScriptProject.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.CdkTypeScriptProject.isConstruct"></a>
 
 ```typescript
 import { CdkTypeScriptProject } from 'cdklabs-projen-project-types'
@@ -10129,20 +9891,6 @@ CdkTypeScriptProject.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.CdkTypeScriptProject.isConstruct.parameter.x"></a>
 
@@ -11095,7 +10843,6 @@ new yarn.Constraints(project: Monorepo, options: ConstraintsOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.yarn.Constraints.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.yarn.Constraints.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.yarn.Constraints.postSynthesize">postSynthesize</a></code> | Called after synthesis. |
 | <code><a href="#cdklabs-projen-project-types.yarn.Constraints.preSynthesize">preSynthesize</a></code> | Called before synthesis. |
 | <code><a href="#cdklabs-projen-project-types.yarn.Constraints.synthesize">synthesize</a></code> | Synthesizes files to the project output directory. |
@@ -11109,27 +10856,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.yarn.Constraints.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.yarn.Constraints.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `postSynthesize` <a name="postSynthesize" id="cdklabs-projen-project-types.yarn.Constraints.postSynthesize"></a>
 
@@ -11166,7 +10892,7 @@ Synthesizes files to the project output directory.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.yarn.Constraints.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.yarn.Constraints.isConstruct"></a>
 
 ```typescript
 import { yarn } from 'cdklabs-projen-project-types'
@@ -11175,20 +10901,6 @@ yarn.Constraints.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.yarn.Constraints.isConstruct.parameter.x"></a>
 
@@ -11275,7 +10987,6 @@ new yarn.Monorepo(options: MonorepoOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.yarn.Monorepo.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.yarn.Monorepo.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.yarn.Monorepo.addExcludeFromCleanup">addExcludeFromCleanup</a></code> | Exclude the matching files from pre-synth cleanup. |
 | <code><a href="#cdklabs-projen-project-types.yarn.Monorepo.addGitIgnore">addGitIgnore</a></code> | Adds a .gitignore pattern. |
 | <code><a href="#cdklabs-projen-project-types.yarn.Monorepo.addPackageIgnore">addPackageIgnore</a></code> | Adds patterns to be ignored by npm. |
@@ -11316,27 +11027,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.yarn.Monorepo.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.yarn.Monorepo.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `addExcludeFromCleanup` <a name="addExcludeFromCleanup" id="cdklabs-projen-project-types.yarn.Monorepo.addExcludeFromCleanup"></a>
 
@@ -11872,7 +11562,7 @@ This is used to resolve dependency versions from `*` to a concrete version const
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.yarn.Monorepo.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.yarn.Monorepo.isConstruct"></a>
 
 ```typescript
 import { yarn } from 'cdklabs-projen-project-types'
@@ -11881,20 +11571,6 @@ yarn.Monorepo.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.yarn.Monorepo.isConstruct.parameter.x"></a>
 
@@ -12887,7 +12563,6 @@ new yarn.MonorepoRelease(project: Project, options?: MonorepoReleaseOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.yarn.MonorepoRelease.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.yarn.MonorepoRelease.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.yarn.MonorepoRelease.postSynthesize">postSynthesize</a></code> | Called after synthesis. |
 | <code><a href="#cdklabs-projen-project-types.yarn.MonorepoRelease.preSynthesize">preSynthesize</a></code> | Called before synthesis. |
 | <code><a href="#cdklabs-projen-project-types.yarn.MonorepoRelease.synthesize">synthesize</a></code> | Synthesizes files to the project output directory. |
@@ -12903,27 +12578,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.yarn.MonorepoRelease.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.yarn.MonorepoRelease.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `postSynthesize` <a name="postSynthesize" id="cdklabs-projen-project-types.yarn.MonorepoRelease.postSynthesize"></a>
 
@@ -12991,7 +12645,7 @@ public workspaceRelease(project: TypeScriptWorkspace): WorkspaceRelease
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.yarn.MonorepoRelease.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.yarn.MonorepoRelease.isConstruct"></a>
 
 ```typescript
 import { yarn } from 'cdklabs-projen-project-types'
@@ -13000,20 +12654,6 @@ yarn.MonorepoRelease.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.yarn.MonorepoRelease.isConstruct.parameter.x"></a>
 
@@ -13127,7 +12767,6 @@ new Rosetta(project: JsiiProject, options?: RosettaOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.Rosetta.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.Rosetta.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.Rosetta.postSynthesize">postSynthesize</a></code> | Called after synthesis. |
 | <code><a href="#cdklabs-projen-project-types.Rosetta.preSynthesize">preSynthesize</a></code> | Called before synthesis. |
 | <code><a href="#cdklabs-projen-project-types.Rosetta.synthesize">synthesize</a></code> | Synthesizes files to the project output directory. |
@@ -13141,27 +12780,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.Rosetta.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.Rosetta.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `postSynthesize` <a name="postSynthesize" id="cdklabs-projen-project-types.Rosetta.postSynthesize"></a>
 
@@ -13198,7 +12816,7 @@ Synthesizes files to the project output directory.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.Rosetta.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.Rosetta.isConstruct"></a>
 
 ```typescript
 import { Rosetta } from 'cdklabs-projen-project-types'
@@ -13207,20 +12825,6 @@ Rosetta.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.Rosetta.isConstruct.parameter.x"></a>
 
@@ -13309,7 +12913,6 @@ new yarn.TypeScriptWorkspace(options: TypeScriptWorkspaceOptions)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.addExcludeFromCleanup">addExcludeFromCleanup</a></code> | Exclude the matching files from pre-synth cleanup. |
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.addGitIgnore">addGitIgnore</a></code> | Adds a .gitignore pattern. |
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.addPackageIgnore">addPackageIgnore</a></code> | Adds patterns to be ignored by npm. |
@@ -13351,27 +12954,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.yarn.TypeScriptWorkspace.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.yarn.TypeScriptWorkspace.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `addExcludeFromCleanup` <a name="addExcludeFromCleanup" id="cdklabs-projen-project-types.yarn.TypeScriptWorkspace.addExcludeFromCleanup"></a>
 
@@ -13922,7 +13504,7 @@ Optionally filter by dependency type.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.yarn.TypeScriptWorkspace.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.yarn.TypeScriptWorkspace.isConstruct"></a>
 
 ```typescript
 import { yarn } from 'cdklabs-projen-project-types'
@@ -13931,20 +13513,6 @@ yarn.TypeScriptWorkspace.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.yarn.TypeScriptWorkspace.isConstruct.parameter.x"></a>
 
@@ -14934,7 +14502,6 @@ new yarn.WorkspaceRelease(project: TypeScriptWorkspace, options: WorkspaceReleas
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceRelease.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceRelease.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceRelease.postSynthesize">postSynthesize</a></code> | Called after synthesis. |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceRelease.preSynthesize">preSynthesize</a></code> | Called before synthesis. |
 | <code><a href="#cdklabs-projen-project-types.yarn.WorkspaceRelease.synthesize">synthesize</a></code> | Synthesizes files to the project output directory. |
@@ -14948,27 +14515,6 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
-
-##### `with` <a name="with" id="cdklabs-projen-project-types.yarn.WorkspaceRelease.with"></a>
-
-```typescript
-public with(mixins: ...IMixin[]): IConstruct
-```
-
-Applies one or more mixins to this construct.
-
-Mixins are applied in order. The list of constructs is captured at the
-start of the call, so constructs added by a mixin will not be visited.
-Use multiple `with()` calls if subsequent mixins should apply to added
-constructs.
-
-###### `mixins`<sup>Required</sup> <a name="mixins" id="cdklabs-projen-project-types.yarn.WorkspaceRelease.with.parameter.mixins"></a>
-
-- *Type:* ...constructs.IMixin[]
-
-The mixins to apply.
-
----
 
 ##### `postSynthesize` <a name="postSynthesize" id="cdklabs-projen-project-types.yarn.WorkspaceRelease.postSynthesize"></a>
 
@@ -15005,7 +14551,7 @@ Synthesizes files to the project output directory.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdklabs-projen-project-types.yarn.WorkspaceRelease.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdklabs-projen-project-types.yarn.WorkspaceRelease.isConstruct"></a>
 
 ```typescript
 import { yarn } from 'cdklabs-projen-project-types'
@@ -15014,20 +14560,6 @@ yarn.WorkspaceRelease.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
-
-Use this method instead of `instanceof` to properly detect `Construct`
-instances, even when the construct library is symlinked.
-
-Explanation: in JavaScript, multiple copies of the `constructs` library on
-disk are seen as independent, completely different libraries. As a
-consequence, the class `Construct` in each copy of the `constructs` library
-is seen as a different class, and an instance of one class will not test as
-`instanceof` the other class. `npm install` will not create installations
-like this, but users may manually symlink construct libraries together or
-use a monorepo tool: in those cases, multiple copies of the `constructs`
-library can be accidentally installed, and `instanceof` will behave
-unpredictably. It is safest to avoid using `instanceof`, and using
-this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdklabs-projen-project-types.yarn.WorkspaceRelease.isConstruct.parameter.x"></a>
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
     "commit-and-tag-version": "^12",
-    "constructs": "^10.0.0",
+    "constructs": "10.0.0",
     "eslint": "^9",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
@@ -54,7 +54,7 @@
     "jsii-pacmak": "^1.127.0",
     "jsii-reflect": "^1.127.0",
     "jsii-rosetta": "~5.9",
-    "projen": "^0.99.48",
+    "projen": "0.99.48",
     "ts-jest": "^29",
     "ts-node": "^10.9.2",
     "typescript": "~5.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2061,7 +2061,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8"
     "@typescript-eslint/parser": "npm:^8"
     commit-and-tag-version: "npm:^12"
-    constructs: "npm:^10.0.0"
+    constructs: "npm:10.0.0"
     eslint: "npm:^9"
     eslint-import-resolver-typescript: "npm:^3.10.1"
     eslint-plugin-import: "npm:^2.32.0"
@@ -2073,7 +2073,7 @@ __metadata:
     jsii-pacmak: "npm:^1.127.0"
     jsii-reflect: "npm:^1.127.0"
     jsii-rosetta: "npm:~5.9"
-    projen: "npm:^0.99.48"
+    projen: "npm:0.99.48"
     ts-jest: "npm:^29"
     ts-node: "npm:^10.9.2"
     typescript: "npm:~5.9"
@@ -2296,6 +2296,13 @@ __metadata:
     readable-stream: "npm:^3.0.2"
     typedarray: "npm:^0.0.6"
   checksum: 10c0/29565dd9198fe1d8cf57f6cc71527dbc6ad67e12e4ac9401feb389c53042b2dceedf47034cbe702dfc4fd8df3ae7e6bfeeebe732cc4fa2674e484c13f04c219a
+  languageName: node
+  linkType: hard
+
+"constructs@npm:10.0.0":
+  version: 10.0.0
+  resolution: "constructs@npm:10.0.0"
+  checksum: 10c0/67a200e2bb582b35210b101ba31f42603650ebf35b88f912a2d2dd66069649e4aa02391252c8f2e2eb4d3fa4d13d57171caf066d4fbafeaf030650914f0b26d4
   languageName: node
   linkType: hard
 
@@ -6109,7 +6116,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"projen@npm:^0.99.48":
+"projen@npm:0.99.48":
   version: 0.99.48
   resolution: "projen@npm:0.99.48"
   dependencies:


### PR DESCRIPTION
The upgrade-dev-deps CI task fails with `TS2339: Property 'InstallReason'` does not exist when `yarn projen` runs synthesis.

The source code uses `javascript.InstallReason`, introduced in `projen v0.99.48`, and the peer dep correctly requires >=0.99.48. However, `pinnedDevDependency` was set to false, which prevented projen from automatically pinning a dev dependency to the peer dep minimum. This allowed the dev dependency to resolve to an older version (0.99.47) that doesn't export `InstallReason.`

Fix
Remove `peerDependencyOptions: { pinnedDevDependency: false }`, restoring the default behavior (true). Projen will now automatically pin the dev dependency to the minimum of the peer range, ensuring the project always builds and tests against a compatible version.