### PR TITLE
chore: remove dependency on projen internal InstallReason enum

### DIFF
--- a/src/yarn/monorepo.ts
+++ b/src/yarn/monorepo.ts
@@ -291,11 +291,11 @@ export class Monorepo extends typescript.TypeScriptProject {
   public postSynthesize() {
     if (this.postInstallDependencies.length) {
       const nodePkg: any = this.package;
-      nodePkg.installDependencies({ reason: javascript.InstallReason.PACKAGE_JSON_CHANGED });
+      nodePkg.installDependencies();
 
       const resolutions = this.postInstallDependencies.flatMap((request) => request());
       if (resolutions.length) {
-        nodePkg.installDependencies({ reason: javascript.InstallReason.DEPS_RESOLVED, resolutions });
+        nodePkg.installDependencies();
       }
 
       this.postInstallDependencies = [];

--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -255,8 +255,8 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
 
     // Instead of installing dependencies, request from the parent
     /* @ts-ignore access private method */
-    this.package.installDependencies = (trigger: javascript.InstallTrigger) => {
-      if (trigger.reason === javascript.InstallReason.NO_NODE_MODULES) {
+    this.package.installDependencies = (trigger?: { reason: string }) => {
+      if (trigger?.reason === 'node_modules is missing') {
         // In a monorepo, a workspace node_modules may legitimately not exist due to hoisting. We just skip this case.
         return;
       }
@@ -267,8 +267,8 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
     /* @ts-ignore access private method */
     const originalLogTrigger = this.package.logInstallTrigger;
     /* @ts-ignore access private method */
-    this.package.logInstallTrigger = (trigger: InstallTrigger) => {
-      if (trigger.reason === javascript.InstallReason.NO_NODE_MODULES) {
+    this.package.logInstallTrigger = (trigger?: { reason: string }) => {
+      if (trigger?.reason === 'node_modules is missing') {
         return;
       }
       /* @ts-ignore access private method */

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -984,7 +984,7 @@ describe('install trigger handling', () => {
     const requestSpy = jest.spyOn(parent, 'requestInstallDependencies');
 
     const pkg: any = ws.package;
-    pkg.installDependencies({ reason: javascript.InstallReason.NO_NODE_MODULES });
+    pkg.installDependencies({ reason: 'node_modules is missing' });
 
     expect(requestSpy).not.toHaveBeenCalled();
   });
@@ -1003,7 +1003,7 @@ describe('install trigger handling', () => {
     const requestSpy = jest.spyOn(parent, 'requestInstallDependencies');
 
     const pkg: any = ws.package;
-    pkg.installDependencies({ reason: javascript.InstallReason.PACKAGE_JSON_CHANGED });
+    pkg.installDependencies({ reason: 'package.json has changed' });
 
     expect(requestSpy).toHaveBeenCalledTimes(1);
   });
@@ -1022,7 +1022,7 @@ describe('install trigger handling', () => {
     const requestSpy = jest.spyOn(parent, 'requestInstallDependencies');
 
     const pkg: any = ws.package;
-    pkg.installDependencies({ reason: javascript.InstallReason.DEPS_RESOLVED, resolutions: ['ms: * => ^2.1.3'] });
+    pkg.installDependencies({ reason: 'resolved dependency versions changed', resolutions: ['ms: * => ^2.1.3'] });
 
     expect(requestSpy).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
After the recent Yarn Berry migration, the `upgrade-dev-deps workflow` uses `yarn up` to update the lockfile. Unlike `yarn upgrade`, `yarn up` ignores the ranges in package.json and upgrades to the absolute latest version of each package ([ref](https://yarnpkg.com/cli/up)). This seems to be causing version bumps that break compilation during the `yarn projen` synthesis step.

One of the resulting errors is `Property 'InstallReason' does not exist on type` where the code references javascript.InstallReason.

Since installDependencies() in projen ignores the trigger parameter entirely ([here](https://github.com/projen/projen/blob/05bfc4475fb891abae8433dd21184c2b1c7ceaba/src/javascript/node-package.ts#L1898)), the fix removes the enum references:

- monorepo.ts: dropped the unused arguments to installDependencies() (the base implementation ignores the trigger parameter)
- typescript-workspace.ts: replaced enum comparisons with their string literal equivalents (e.g. 'node_modules is missing') and used inline types instead of the removed InstallTrigger interface
- cdklabs-monorepo.test.ts: same enum-to-string-literal swap

This fixes the immediate compilation error, but I'm unsure if a long term fix to `yarn up`'s behavior is needed