### PR TITLE
fix(yarn): topological release ordering for workspace dependencies

### DIFF
--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { github, release as projenRelease, Component, Project, Task } from 'projen';
+import { DependencyType, github, release as projenRelease, Component, Project, Task } from 'projen';
 import { BUILD_ARTIFACT_NAME, PERMISSION_BACKUP_FILE } from 'projen/lib/github/constants';
 import { Tools } from 'projen/lib/github/workflows-model';
 import { MonorepoReleaseOptions } from './monorepo-release-options';
@@ -133,11 +133,20 @@ export class MonorepoRelease extends Component {
   }
 
   private renderPublishJobs() {
-    for (const { release } of this.packagesToRelease) {
-      const packagePublishJobs = release.publisher._renderJobsForBranch(this.branchName, release.options);
+    // First pass: render jobs and collect prefixed job keys per workspace
+    const publishJobsByWorkspace = new Map<string, {
+      prefix: string;
+      jobs: Record<string, github.workflows.Job>;
+      release: { workspace: TypeScriptWorkspace; publisher: projenRelease.Publisher; options: Partial<projenRelease.BranchOptions> };
+      jobKeys: string[];
+    }>();
 
-      for (const job of Object.values(packagePublishJobs)) {
-        // Find the 'download-artifact' job and replace the build artifact name with the unique per-project one
+    for (const { release } of this.packagesToRelease) {
+      const jobs = release.publisher._renderJobsForBranch(this.branchName, release.options);
+      const prefix = slugify(`${release.workspace.name}`);
+
+      for (const job of Object.values(jobs)) {
+        // Replace the build artifact name with the unique per-project one
         const downloadStep = job.steps.find((j) => j.uses?.startsWith('actions/download-artifact@'));
         if (!downloadStep) {
           throw new Error(`Could not find downloadStep among steps: ${JSON.stringify(job.steps, undefined, 2)}`);
@@ -145,20 +154,38 @@ export class MonorepoRelease extends Component {
         (downloadStep.with ?? {}).name = buildArtifactName(release.workspace);
       }
 
+      publishJobsByWorkspace.set(release.workspace.name, {
+        prefix,
+        jobs,
+        release,
+        jobKeys: Object.keys(jobs).map(k => `${prefix}_${k}`),
+      });
+    }
+
+    // Second pass: add topological needs and inject jobs into workflow
+    for (const { prefix, jobs, release } of publishJobsByWorkspace.values()) {
+
+      // Determine runtime dependency job keys for topological ordering
+      const runtimeDepJobKeys = release.workspace.workspaceDependencies([DependencyType.RUNTIME, DependencyType.PEER])
+        .flatMap((dep: Project) => publishJobsByWorkspace.get(dep.name)?.jobKeys ?? []);
+
       // Make the job names unique
       this.workflow?.addJobs(
         Object.fromEntries(
-          Object.entries(packagePublishJobs).map(([key, job]) => {
-            const prefix = slugify(`${release.workspace.name}`);
-            const needs = (job.needs ?? []).map(dep => {
-              // All publish jobs depend on the main release job
-              if (dep === 'release') {
-                return dep;
-              }
+          Object.entries(jobs).map(([key, job]) => {
+            const needs = [
+              ...(job.needs ?? []).map((dep: string) => {
+                // All publish jobs depend on the main release job
+                if (dep === 'release') {
+                  return dep;
+                }
 
-              // ... and possibly on individual publish jobs that are prefixed
-              return `${prefix}_${dep}`;
-            });
+                // ... and possibly on individual publish jobs that are prefixed
+                return `${prefix}_${dep}`;
+              }),
+              // Add topological dependencies on runtime dep publish jobs
+              ...runtimeDepJobKeys,
+            ];
 
             // we build the tools object so that we can modify it with our
             // own custom properties.

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -524,6 +524,65 @@ describe('CdkLabsMonorepo', () => {
       // Checking for the correct invocation of the gather-versions script
       expect(tasks.tasks['gather-versions'].steps[0].exec).toContain('@cdklabs/one=exact');
     });
+
+    test('publish jobs have topological needs on runtime workspace dependencies', () => {
+      const dep = new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/dep',
+      });
+
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/consumer',
+        deps: [dep],
+      });
+
+      const outdir = Testing.synth(parent);
+      const releaseWorkflow = YAML.parse(outdir['.github/workflows/release.yml']);
+
+      // consumer's npm job should need dep's publish jobs
+      expect(releaseWorkflow.jobs['cdklabs-consumer_release_npm'].needs).toContain('cdklabs-dep_release_npm');
+      expect(releaseWorkflow.jobs['cdklabs-consumer_release_npm'].needs).toContain('cdklabs-dep_release_github');
+
+      // dep's npm job should NOT need consumer's jobs
+      expect(releaseWorkflow.jobs['cdklabs-dep_release_npm'].needs).not.toContain('cdklabs-consumer_release_npm');
+    });
+
+    test('devDeps on a workspace do not add release dependency', () => {
+      const dep = new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/dep',
+      });
+
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/consumer',
+        devDeps: [dep],
+      });
+
+      const outdir = Testing.synth(parent);
+      const releaseWorkflow = YAML.parse(outdir['.github/workflows/release.yml']);
+
+      expect(releaseWorkflow.jobs['cdklabs-consumer_release_npm'].needs).not.toContain('cdklabs-dep_release_npm');
+    });
+
+    test('peerDeps on a workspace add release dependency', () => {
+      const dep = new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/dep',
+      });
+
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/consumer',
+        peerDeps: [dep],
+      });
+
+      const outdir = Testing.synth(parent);
+      const releaseWorkflow = YAML.parse(outdir['.github/workflows/release.yml']);
+
+      expect(releaseWorkflow.jobs['cdklabs-consumer_release_npm'].needs).toContain('cdklabs-dep_release_npm');
+    });
   });
 
   describe('monorepo dependency upgrades', () => {


### PR DESCRIPTION
The monorepo release workflow publishes all packages in parallel. When package A has a runtime dependency on package B and package B fails to release, package A gets published referencing a version of B that doesn't exist on npm.

This adds topological ordering to the release workflow by injecting `needs` on the dependent package's publish jobs. Only runtime and peer dependencies trigger this ordering — devDeps do not, since they aren't required at install time.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
