### PR TITLE
feat(release): add dry-run workflow input to monorepo release

### DIFF
--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -354,6 +354,20 @@ export class MonorepoRelease extends Component {
       postBuildSteps,
       runsOn: this.options.workflowRunsOn,
     });
+
+    // Override the default empty workflow_dispatch added by TaskWorkflow
+    // to include the dry_run input for testing the release pipeline
+    this.workflow.on({
+      workflowDispatch: {
+        inputs: {
+          dry_run: {
+            description: 'Dry run (skip actual publishing)',
+            required: false,
+            type: 'boolean',
+          },
+        },
+      },
+    });
   }
 }
 

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -2939,7 +2939,12 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Dry run (skip actual publishing)
+        required: false
+        type: boolean
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `dry_run` boolean checkbox input to the monorepo release workflow's `workflow_dispatch` trigger, matching the feature added to projen's `Release` component in https://github.com/projen/projen/pull/4690.

When checked, publib stages receive `PUBLIB_DRYRUN=true` in their env (handled natively by publib), and the GitHub Releases step is skipped. This is already wired up by projen's `Publisher._renderJobsForBranch` — the only missing piece was declaring the input on the workflow trigger itself.

Note: `TaskWorkflow` always appends an empty `workflowDispatch: {}` after processing the `triggers` option, so the input is added via a separate `this.workflow.on()` call after construction to avoid being overwritten.

---

Fixes #
