### PR TITLE
fix(monorepo): skipped upstream publish jobs cascade incorrectly

### DIFF
--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -198,15 +198,19 @@ export class MonorepoRelease extends Component {
               },
             };
 
+            const condition = `needs.release.outputs.latest_commit == github.sha && needs.release.outputs.${publishProjectOutputId(
+              release.workspace,
+            )} == 'true'`;
+
             return [
               `${prefix}_${key}`,
               {
                 ...job,
                 tools: toolsRebuilt,
                 needs,
-                if: `\${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.${publishProjectOutputId(
-                  release.workspace,
-                )} == 'true' }}`,
+                if: runtimeDepJobKeys.length > 0
+                  ? `\${{ !cancelled() && !failure() && ${condition} }}`
+                  : `\${{ ${condition} }}`,
                 name: `${release.workspace.name}: ${job.name}`,
               },
             ];

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -548,6 +548,28 @@ describe('CdkLabsMonorepo', () => {
       expect(releaseWorkflow.jobs['cdklabs-dep_release_npm'].needs).not.toContain('cdklabs-consumer_release_npm');
     });
 
+    test('publish jobs with topological needs include !cancelled() && !failure() in if condition', () => {
+      const dep = new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/dep',
+      });
+
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/consumer',
+        deps: [dep],
+      });
+
+      const outdir = Testing.synth(parent);
+      const releaseWorkflow = YAML.parse(outdir['.github/workflows/release.yml']);
+
+      // consumer's job has topological deps, so it should tolerate skipped upstream jobs
+      expect(releaseWorkflow.jobs['cdklabs-consumer_release_npm'].if).toContain('!cancelled() && !failure()');
+
+      // dep's job has no topological deps, so it should NOT have the extra condition
+      expect(releaseWorkflow.jobs['cdklabs-dep_release_npm'].if).not.toContain('!cancelled() && !failure()');
+    });
+
     test('devDeps on a workspace do not add release dependency', () => {
       const dep = new yarn.TypeScriptWorkspace({
         parent,


### PR DESCRIPTION
In monorepo releases, when an upstream package has no new version to publish, its publish jobs are skipped. GitHub Actions treats a `skipped` conclusion as not satisfying the implicit success requirement for downstream `needs` jobs — even when those jobs have an explicit `if` condition. This causes downstream packages that *do* have changes to also be skipped incorrectly.

This fix prepends `!cancelled() && !failure()` to the `if` condition on publish jobs that have topological dependencies on other publish jobs. This overrides the default behavior so that skipped upstream jobs no longer block downstream publishing, while still preventing execution if an upstream job actually fails.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
