### PR TITLE
fix(yarn): publish gate skips packages whose dependencies are not republished

### DIFF
--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -493,7 +493,8 @@ class PackageReleaseNode {
         pubNode.jobId,
         {
           ...pubNode.job,
-          if: undefined,
+          // Tolerate skipped dependency ancestors while still requiring this package's gate to pass
+          if: `\${{ !cancelled() && !failure() && needs.${this.gateJobId}.result == 'success' }}`,
           tools: {
             ...pubNode.job.tools,
             node: {

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -2982,6 +2982,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-schema_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3007,6 +3008,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-schema_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3052,6 +3054,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-api_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3079,6 +3082,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-api_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3124,6 +3128,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-diff_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3151,6 +3156,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-diff_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3196,6 +3202,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-toolkit_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3224,6 +3231,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-toolkit_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3269,6 +3277,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-cli_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3296,6 +3305,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-cli_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3341,6 +3351,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-integ-runner_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3368,6 +3379,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-integ-runner_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3751,6 +3763,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-one_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3776,6 +3789,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-one_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3821,6 +3835,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-two_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -3846,6 +3861,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-two_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -8335,6 +8351,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-base_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -8360,6 +8377,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-base_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -8405,6 +8423,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-mid_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -8432,6 +8451,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-mid_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -8477,6 +8497,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-top_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -8504,6 +8525,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: \${{ !cancelled() && !failure() && needs.cdklabs-top_release.result == 'success' }}
     steps:
       - uses: actions/setup-node@v6
         with:

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -639,9 +639,9 @@ describe('CdkLabsMonorepo', () => {
       expect(toolkitGhNeeds).toContain('cdklabs-toolkit_release_npm');
       expect(toolkitGhNeeds).not.toEqual(expect.arrayContaining(['cdklabs-toolkit_release']));
 
-      // Publish jobs have no if condition — all gating is done by the package gate
-      expect(releaseWorkflow.jobs['cdklabs-toolkit_release_npm'].if).toBeUndefined();
-      expect(releaseWorkflow.jobs['cdklabs-integ-runner_release_npm'].if).toBeUndefined();
+      // Publish jobs tolerate skipped dependency ancestors while gating on the package gate
+      expect(releaseWorkflow.jobs['cdklabs-toolkit_release_npm'].if).toBe("${{ !cancelled() && !failure() && needs.cdklabs-toolkit_release.result == 'success' }}");
+      expect(releaseWorkflow.jobs['cdklabs-integ-runner_release_npm'].if).toBe("${{ !cancelled() && !failure() && needs.cdklabs-integ-runner_release.result == 'success' }}");
 
       // No publish job directly accesses release job outputs
       // (prevents invalid GitHub Actions context access warnings)


### PR DESCRIPTION
The gate refactor in v0.4.0 introduced a regression where packages with dependency packages that are not being republished in the same run get silently skipped — even when the package itself was selected by the gate.

The root cause is that the refactor moved package selection into `<pkg>_release` trigger jobs and set `if: undefined` on publish jobs. Without an explicit status-check function, GitHub Actions applies the implicit `success()` gate over the transitive `needs` closure. If any ancestor job (e.g. a dependency package's publish job) was skipped, the downstream publish job is poisoned and skipped too.

This restores a status-check function on generated publish jobs that tolerates skipped dependency ancestors while still gating on the package's own selection signal:
```yaml
if: ${{ !cancelled() && !failure() && needs.<pkg>_release.result == 'success' }}
```

The `*_release_done` dependency remains for ordering only (publish dependencies first if they are also publishing), never as a gating signal.
