### PR TITLE
feat(yarn): add `addWorkspaceDep` method to TypeScriptWorkspace

### DIFF
--- a/API.md
+++ b/API.md
@@ -13339,6 +13339,7 @@ new yarn.TypeScriptWorkspace(options: TypeScriptWorkspaceOptions)
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.removeScript">removeScript</a></code> | Removes the npm script (always successful). |
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.renderWorkflowSetup">renderWorkflowSetup</a></code> | Returns the set of workflow steps which should be executed to bootstrap a workflow. |
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.setScript">setScript</a></code> | Replaces the contents of an npm package.json script. |
+| <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.addWorkspaceDep">addWorkspaceDep</a></code> | Add a workspace package as a dependency, including tsconfig project references. |
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.customizeReference">customizeReference</a></code> | Return a specialized reference to this workspace. |
 | <code><a href="#cdklabs-projen-project-types.yarn.TypeScriptWorkspace.workspaceDependencies">workspaceDependencies</a></code> | Return all Projects in the workspace that are also dependencies. |
 
@@ -13879,6 +13880,29 @@ The script name.
 - *Type:* string
 
 The command to execute.
+
+---
+
+##### `addWorkspaceDep` <a name="addWorkspaceDep" id="cdklabs-projen-project-types.yarn.TypeScriptWorkspace.addWorkspaceDep"></a>
+
+```typescript
+public addWorkspaceDep(ref: IWorkspaceReference, type?: DependencyType): void
+```
+
+Add a workspace package as a dependency, including tsconfig project references.
+
+Use this to add workspace dependencies after construction (e.g. from a mixin).
+It does the same as passing the workspace in the `deps`/`devDeps`/`peerDeps` constructor option.
+
+###### `ref`<sup>Required</sup> <a name="ref" id="cdklabs-projen-project-types.yarn.TypeScriptWorkspace.addWorkspaceDep.parameter.ref"></a>
+
+- *Type:* cdklabs-projen-project-types.yarn.IWorkspaceReference
+
+---
+
+###### `type`<sup>Optional</sup> <a name="type" id="cdklabs-projen-project-types.yarn.TypeScriptWorkspace.addWorkspaceDep.parameter.type"></a>
+
+- *Type:* projen.DependencyType
 
 ---
 

--- a/src/yarn/gather-versions.task.ts
+++ b/src/yarn/gather-versions.task.ts
@@ -13,11 +13,14 @@ export interface GatherVersionsOptions {
 export class GatherVersions implements TaskOptions, TaskStep {
   public receiveArgs = true;
 
-  private repoDependencies: Record<string, VersionType>;
+  private readonly options: GatherVersionsOptions;
 
   public constructor(public readonly project: TypeScriptWorkspace, options: GatherVersionsOptions) {
-    // Start by building a list of all repo devdependencies and map them to an 'exact' dependency,
-    // then add in the runtime dependencies. Only devs and peers can clash this way, peer will win.
+    this.options = options;
+  }
+
+  private get repoDependencies(): Record<string, VersionType> {
+    // Build list at access time so lazily-added workspace deps are included
     const wsDeps = new Set(this.project.workspaceDependencies().map(p => p.name));
 
     const repoDevDependencies = Object.fromEntries(devDeps(this.project)
@@ -25,9 +28,9 @@ export class GatherVersions implements TaskOptions, TaskStep {
       .map((d) => [d.name, 'exact'] satisfies [string, VersionType]),
     );
 
-    this.repoDependencies = {
+    return {
       ...repoDevDependencies,
-      ...options.repoRuntimeDependencies,
+      ...this.options.repoRuntimeDependencies,
     };
   }
 

--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -62,6 +62,9 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
   public readonly versionType = 'future-minor';
 
   private readonly monorepo: Monorepo;
+  private readonly allowPrivateDeps: boolean;
+  private readonly excludeFromUpgrade: string[];
+  private readonly repoRuntimeDeps: Record<string, VersionType> = {};
 
   constructor(options: TypeScriptWorkspaceOptions) {
     const remainder = without(
@@ -87,6 +90,10 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
     const npmAccess = options.parent.monorepoRelease && !options.private ? javascript.NpmAccess.PUBLIC : undefined;
 
     const releaseEnvironment = options.releaseEnvironment ?? options.parent.options.releaseEnvironment;
+
+    const excludeFromUpgrade = [
+      ...(options.excludeDepsFromUpgrade ?? []),
+    ];
 
     super({
       parent: options.parent,
@@ -118,9 +125,12 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
         : undefined,
       sampleCode: false,
 
-      deps: packageNames(options.deps),
-      peerDeps: packageNames(options.peerDeps),
-      devDeps: packageNames(options.devDeps),
+      // add non workspace dependencies here
+      // workspace refs are added later
+      deps: options.deps?.filter(isNotWorkspaceReference),
+      peerDeps: options.peerDeps?.filter(isNotWorkspaceReference),
+      devDeps: options.devDeps?.filter(isNotWorkspaceReference),
+
       projenDevDependency: true,
       releaseEnvironment,
 
@@ -128,12 +138,7 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
       depsUpgradeOptions: {
         workflow: false,
         cooldown: options.parent.options.depsUpgradeOptions?.cooldown ?? (options.parent.options.yarnBerry ? 3 : undefined),
-        exclude: [
-          ...(options.excludeDepsFromUpgrade ?? []),
-          ...(packageNames(options.deps?.filter(isWorkspaceReference)) ?? []),
-          ...(packageNames(options.peerDeps?.filter(isWorkspaceReference)) ?? []),
-          ...(packageNames(options.devDeps?.filter(isWorkspaceReference)) ?? []),
-        ],
+        exclude: excludeFromUpgrade,
       },
 
       npmAccess,
@@ -147,25 +152,9 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
 
     this.monorepo = options.parent;
     this.isPrivatePackage = options.private ?? false;
+    this.allowPrivateDeps = options.allowPrivateDeps ?? false;
+    this.excludeFromUpgrade = excludeFromUpgrade;
     this.workspaceDirectory = workspaceDirectory;
-
-    // If the package is public, all local deps and peer deps must also be public and other TypeScriptWorkspaces
-    if (!this.isPrivatePackage) {
-      const illegalDeps = [
-        // Overridable for deps because this might make sense if we bundle the package.
-        ...options.deps?.filter(isWorkspaceReference).filter(w => w.isPrivatePackage && !options.allowPrivateDeps) ?? [],
-        // But not for peerDeps, they must always be installed by the user.
-        ...options.peerDeps?.filter(isWorkspaceReference).filter(w => w.isPrivatePackage) ?? [],
-        // devDeps can be private, we don't care.
-      ];
-
-      if (illegalDeps.length) {
-        throw new Error([
-          `${this.name} is public and cannot depend on any private packages from the workspace.`,
-          `Please fix these dependencies:\n    - ${illegalDeps.map((p) => p.name).join('\n    - ')}`,
-        ].join('\n'));
-      }
-    }
 
     // Register with release workflow
     this.monorepo.monorepoRelease?.addWorkspace(this, {
@@ -182,10 +171,7 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
         minMajorVersion: options.minMajorVersion,
         prerelease: options.prerelease,
       },
-      repoRuntimeDependencies: Object.fromEntries([
-        ...options.deps ?? [],
-        ...options.peerDeps ?? [],
-      ].filter(isWorkspaceReference).map(w => [w.name, w.versionType])),
+      repoRuntimeDependencies: this.repoRuntimeDeps,
     });
 
     // Expose the monorepo publisher as project.release so that other code can find it via project.release?.publisher
@@ -235,14 +221,20 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
     }
 
     // Composite project and references
-    const allDeps = [...(options.deps ?? []), ...(options.peerDeps ?? []), ...(options.devDeps ?? [])];
-
     for (const tsconfig of [this.tsconfig, this.tsconfigDev]) {
       tsconfig?.file.addOverride('compilerOptions.composite', true);
-      tsconfig?.file.addOverride(
-        'references',
-        allDeps.filter(isWorkspaceReference).map((p) => ({ path: relative(this.outdir, p.outdir) })),
-      );
+      tsconfig?.file.addOverride('references', []);
+    }
+
+    // Add workspace references
+    for (const dep of options.deps?.filter(isWorkspaceReference) ?? []) {
+      this.addWorkspaceDep(dep, DependencyType.RUNTIME);
+    }
+    for (const dep of options.peerDeps?.filter(isWorkspaceReference) ?? []) {
+      this.addWorkspaceDep(dep, DependencyType.PEER);
+    }
+    for (const dep of options.devDeps?.filter(isWorkspaceReference) ?? []) {
+      this.addWorkspaceDep(dep, DependencyType.BUILD);
     }
 
     // Allow passing additional args like `--force` to the compile task
@@ -333,6 +325,73 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
   }
 
   /**
+   * Add a workspace package as a dependency, including tsconfig project references.
+   *
+   * Use this to add workspace dependencies after construction (e.g. from a mixin).
+   * It does the same as passing the workspace in the `deps`/`devDeps`/`peerDeps` constructor option.
+   */
+  public addWorkspaceDep(ref: IWorkspaceReference, type: DependencyType = DependencyType.RUNTIME): void {
+    if (this.deps.tryGetDependency(ref.name)) {
+      return;
+    }
+    switch (type) {
+      case DependencyType.RUNTIME:
+        this.addDeps(ref.name);
+        break;
+      case DependencyType.PEER:
+        this.addPeerDeps(ref.name);
+        break;
+      case DependencyType.DEVENV:
+      case DependencyType.BUILD:
+      case DependencyType.TEST:
+        this.addDevDeps(ref.name);
+        break;
+      default:
+        this.addDeps(ref.name);
+    }
+    const relativePath = relative(this.outdir, ref.outdir);
+    for (const tsconfig of [this.tsconfig, this.tsconfigDev]) {
+      tsconfig?.file.addToArray('references', { path: relativePath });
+    }
+    this.excludeFromUpgrade.push(ref.name);
+    if (type === DependencyType.RUNTIME || type === DependencyType.PEER) {
+      this.repoRuntimeDeps[ref.name] = ref.versionType;
+    }
+  }
+
+  public preSynthesize(): void {
+    super.preSynthesize();
+    this.validateNoPrivateWorkspaceDeps();
+  }
+
+  private validateNoPrivateWorkspaceDeps(): void {
+    if (this.isPrivatePackage) return;
+
+    const siblings = new Map(
+      this.monorepo.subprojects
+        .filter((p): p is TypeScriptWorkspace => p instanceof TypeScriptWorkspace)
+        .map((p) => [p.name, p]),
+    );
+
+    const illegalDeps = this.deps.all
+      .filter((d) => d.type === DependencyType.RUNTIME || d.type === DependencyType.PEER)
+      .filter((d) => {
+        const ws = siblings.get(d.name);
+        if (!ws?.isPrivatePackage) return false;
+        if (d.type === DependencyType.RUNTIME && this.allowPrivateDeps) return false;
+        return true;
+      })
+      .map((d) => d.name);
+
+    if (illegalDeps.length) {
+      throw new Error([
+        `${this.name} is public and cannot depend on private workspace packages.`,
+        `Illegal dependencies:\n    - ${illegalDeps.join('\n    - ')}`,
+      ].join('\n'));
+    }
+  }
+
+  /**
    * Return all Projects in the workspace that are also dependencies.
    *
    * Optionally filter by dependency type.
@@ -373,13 +432,6 @@ export interface ReferenceOptions {
   readonly versionType?: VersionType;
 }
 
-function packageNames(xs?: Array<string | IWorkspaceReference>): string[] | undefined {
-  if (!xs) {
-    return undefined;
-  }
-  return xs.map((x) => (typeof x === 'string' ? x : x.name));
-}
-
 function without<A extends object, K extends keyof A>(x: A, ...ks: K[]): Omit<A, K> {
   const ret = { ...x };
   for (const k of ks) {
@@ -390,4 +442,8 @@ function without<A extends object, K extends keyof A>(x: A, ...ks: K[]): Omit<A,
 
 function isWorkspaceReference(x: unknown): x is IWorkspaceReference {
   return typeof x === 'object' && !!x && (['isPrivatePackage', 'versionType', 'name', 'outdir'] satisfies Array<keyof IWorkspaceReference>).every(k => (x as any)[k] !== undefined);
+}
+
+function isNotWorkspaceReference(x: unknown): x is string {
+  return !isWorkspaceReference(x);
 }

--- a/test/add-workspace-dep.test.ts
+++ b/test/add-workspace-dep.test.ts
@@ -1,0 +1,157 @@
+import { DependencyType } from 'projen';
+import { Testing } from 'projen/lib/testing';
+import { yarn } from '../src';
+
+describe('addWorkspaceDep', () => {
+  let parent: yarn.CdkLabsMonorepo;
+  beforeEach(() => {
+    parent = new yarn.CdkLabsMonorepo({
+      name: 'monorepo',
+      defaultReleaseBranch: 'main',
+    });
+  });
+
+  test('adds a runtime dependency and tsconfig reference', () => {
+    const dep = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep' });
+    const consumer = new yarn.TypeScriptWorkspace({ parent, name: '@scope/consumer' });
+
+    consumer.addWorkspaceDep(dep);
+
+    const outdir = Testing.synth(parent);
+    const deps = outdir['packages/@scope/consumer/.projen/deps.json'];
+    expect(deps.dependencies).toContainEqual(expect.objectContaining({ name: '@scope/dep', type: 'runtime' }));
+
+    const tsconfig = outdir['packages/@scope/consumer/tsconfig.json'];
+    expect(tsconfig.references).toContainEqual({ path: '../dep' });
+  });
+
+  test('adds a dev dependency and tsconfig reference', () => {
+    const dep = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep', private: true });
+    const consumer = new yarn.TypeScriptWorkspace({ parent, name: '@scope/consumer' });
+
+    consumer.addWorkspaceDep(dep, DependencyType.BUILD);
+
+    const outdir = Testing.synth(parent);
+    const deps = outdir['packages/@scope/consumer/.projen/deps.json'];
+    expect(deps.dependencies).toContainEqual(expect.objectContaining({ name: '@scope/dep', type: 'build' }));
+
+    const tsconfig = outdir['packages/@scope/consumer/tsconfig.json'];
+    expect(tsconfig.references).toContainEqual({ path: '../dep' });
+  });
+
+  test('adds a peer dependency and tsconfig reference', () => {
+    const dep = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep' });
+    const consumer = new yarn.TypeScriptWorkspace({ parent, name: '@scope/consumer' });
+
+    consumer.addWorkspaceDep(dep, DependencyType.PEER);
+
+    const outdir = Testing.synth(parent);
+    const deps = outdir['packages/@scope/consumer/.projen/deps.json'];
+    expect(deps.dependencies).toContainEqual(expect.objectContaining({ name: '@scope/dep', type: 'peer' }));
+
+    const tsconfig = outdir['packages/@scope/consumer/tsconfig.json'];
+    expect(tsconfig.references).toContainEqual({ path: '../dep' });
+  });
+
+  test('is a no-op if dependency already exists', () => {
+    const dep = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep' });
+    const consumer = new yarn.TypeScriptWorkspace({ parent, name: '@scope/consumer', deps: [dep] });
+
+    // Should not throw or duplicate
+    consumer.addWorkspaceDep(dep);
+
+    const outdir = Testing.synth(parent);
+    const deps = outdir['packages/@scope/consumer/.projen/deps.json'];
+    const matches = deps.dependencies.filter((d: any) => d.name === '@scope/dep');
+    expect(matches).toHaveLength(1);
+  });
+
+  test('appends to existing references from constructor deps', () => {
+    const dep1 = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep1' });
+    const dep2 = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep2' });
+    const consumer = new yarn.TypeScriptWorkspace({ parent, name: '@scope/consumer', deps: [dep1] });
+
+    consumer.addWorkspaceDep(dep2);
+
+    const outdir = Testing.synth(parent);
+    const tsconfig = outdir['packages/@scope/consumer/tsconfig.json'];
+    expect(tsconfig.references).toContainEqual({ path: '../dep1' });
+    expect(tsconfig.references).toContainEqual({ path: '../dep2' });
+  });
+
+  test('preSynthesize catches private dep added via addWorkspaceDep', () => {
+    const dep = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep', private: true });
+    const consumer = new yarn.TypeScriptWorkspace({ parent, name: '@scope/consumer' });
+
+    consumer.addWorkspaceDep(dep);
+
+    expect(() => Testing.synth(parent)).toThrow(/cannot depend on private workspace packages/);
+  });
+
+  test('allowPrivateDeps suppresses error for runtime deps', () => {
+    const dep = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep', private: true });
+    const consumer = new yarn.TypeScriptWorkspace({ parent, name: '@scope/consumer', allowPrivateDeps: true });
+
+    consumer.addWorkspaceDep(dep, DependencyType.RUNTIME);
+
+    // Should not throw
+    expect(() => Testing.synth(parent)).not.toThrow();
+  });
+
+  test('allowPrivateDeps does not suppress error for peer deps', () => {
+    const dep = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep', private: true });
+    const consumer = new yarn.TypeScriptWorkspace({ parent, name: '@scope/consumer', allowPrivateDeps: true });
+
+    consumer.addWorkspaceDep(dep, DependencyType.PEER);
+
+    expect(() => Testing.synth(parent)).toThrow(/cannot depend on private workspace packages/);
+  });
+
+  test('lazily added dep is excluded from upgrade task', () => {
+    const dep = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep' });
+    const consumer = new yarn.TypeScriptWorkspace({ parent, name: '@scope/consumer' });
+
+    consumer.addWorkspaceDep(dep);
+
+    const outdir = Testing.synth(parent);
+    const tasks = outdir['packages/@scope/consumer/.projen/tasks.json'];
+    const checkForUpdates = tasks.tasks['check-for-updates'];
+    const ncu = checkForUpdates.steps.find((s: any) => s.exec?.includes('npm-check-updates'));
+    // @scope/dep should NOT be in the filter (i.e. it's excluded)
+    expect(ncu.exec).not.toContain('@scope/dep');
+  });
+
+  test('lazily added runtime dep appears in gather-versions task', () => {
+    const relParent = new yarn.CdkLabsMonorepo({
+      name: 'monorepo',
+      defaultReleaseBranch: 'main',
+      release: true,
+    });
+    const dep = new yarn.TypeScriptWorkspace({ parent: relParent, name: '@scope/dep' });
+    const consumer = new yarn.TypeScriptWorkspace({ parent: relParent, name: '@scope/consumer' });
+
+    consumer.addWorkspaceDep(dep, DependencyType.RUNTIME);
+
+    const outdir = Testing.synth(relParent);
+    const tasks = outdir['packages/@scope/consumer/.projen/tasks.json'];
+    const gatherVersions = tasks.tasks['gather-versions'];
+    expect(gatherVersions.steps[0].exec).toContain('@scope/dep=future-minor');
+  });
+
+  test('lazily added dev dep appears as exact in gather-versions', () => {
+    const relParent = new yarn.CdkLabsMonorepo({
+      name: 'monorepo',
+      defaultReleaseBranch: 'main',
+      release: true,
+    });
+    const dep = new yarn.TypeScriptWorkspace({ parent: relParent, name: '@scope/dep', private: true });
+    const consumer = new yarn.TypeScriptWorkspace({ parent: relParent, name: '@scope/consumer', allowPrivateDeps: true });
+
+    consumer.addWorkspaceDep(dep, DependencyType.BUILD);
+
+    const outdir = Testing.synth(relParent);
+    const tasks = outdir['packages/@scope/consumer/.projen/tasks.json'];
+    const gatherVersions = tasks.tasks['gather-versions'];
+    expect(gatherVersions.steps[0].exec).toContain('@scope/dep=exact');
+  });
+});

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -74,13 +74,13 @@ describe('CdkLabsMonorepo', () => {
         private: true,
       });
 
-      expect(() => {
-        new yarn.TypeScriptWorkspace({
-          parent,
-          name: '@cdklabs/two',
-          deps: [privDep],
-        });
-      }).toThrow(/cannot depend on any private packages/);
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/two',
+        deps: [privDep],
+      });
+
+      expect(() => Testing.synth(parent)).toThrow(/cannot depend on private workspace packages/);
     });
 
     test('public dependency on a private package error can be suppressed', () => {
@@ -107,14 +107,14 @@ describe('CdkLabsMonorepo', () => {
         private: true,
       });
 
-      expect(() => {
-        new yarn.TypeScriptWorkspace({
-          parent,
-          name: '@cdklabs/two',
-          peerDeps: [privDep],
-          allowPrivateDeps: true,
-        });
-      }).toThrow(/cannot depend on any private packages/);
+      new yarn.TypeScriptWorkspace({
+        parent,
+        name: '@cdklabs/two',
+        peerDeps: [privDep],
+        allowPrivateDeps: true,
+      });
+
+      expect(() => Testing.synth(parent)).toThrow(/cannot depend on private workspace packages/);
     });
 
     test('workspace dependencies synthesize to asterisk by default', () => {


### PR DESCRIPTION
Adds a public `addWorkspaceDep(ref, type?)` method to `TypeScriptWorkspace` that enables adding workspace dependencies post-construction — the primary use case being projen mixins that need to declare workspace deps on the target project.

This method is now the single code path for all workspace reference handling. The constructor itself uses it internally for deps/peerDeps/devDeps that are `IWorkspaceReference` objects. This means all workspace deps — whether added at construction or later via a mixin — get the same treatment:

- Dependency added with correct type (runtime/dev/peer)
- tsconfig project references appended
- Excluded from npm-check-updates upgrade task
- Tracked in gather-versions for release versioning

The private-deps validation (`public package cannot depend on private workspace packages`) is moved from the constructor to `preSynthesize()` so it catches deps added post-construction too.

`GatherVersions` now computes its dependency map lazily (via a getter instead of constructor assignment) so that workspace deps added after construction are visible at synth time.

---

Motivation: The AWS CDK CLI repo needs a `ToolMixin` (projen `IMixin`) that adds `@aws-cdk/tools` as a workspace dev dependency to consuming packages. Without `addWorkspaceDep`, there was no way to properly add a workspace reference post-construction — you could only add a string dep (missing tsconfig refs, upgrade exclusions, and gather-versions tracking).
