### PR TITLE
fix(yarn): tsconfig project reference path ignores tsconfig file location

### DIFF
--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -1,5 +1,5 @@
 
-import { relative } from 'path';
+import { dirname, relative } from 'path';
 import { Component, javascript, typescript, TaskStep, SourceCode, DependencyType, Project } from 'projen';
 import { Monorepo } from './monorepo';
 import { TypeScriptWorkspaceOptions } from './typescript-workspace-options';
@@ -349,9 +349,11 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
       default:
         this.addDeps(ref.name);
     }
-    const relativePath = relative(this.outdir, ref.outdir);
     for (const tsconfig of [this.tsconfig, this.tsconfigDev]) {
-      tsconfig?.file.addToArray('references', { path: relativePath });
+      if (tsconfig) {
+        const relativePath = relative(dirname(tsconfig.file.absolutePath), ref.outdir);
+        tsconfig?.file.addToArray('references', { path: relativePath });
+      }
     }
     this.excludeFromUpgrade.push(ref.name);
     if (type === DependencyType.RUNTIME || type === DependencyType.PEER) {

--- a/test/add-workspace-dep.test.ts
+++ b/test/add-workspace-dep.test.ts
@@ -138,6 +138,30 @@ describe('addWorkspaceDep', () => {
     expect(gatherVersions.steps[0].exec).toContain('@scope/dep=future-minor');
   });
 
+  test('tsconfig reference path is relative to the tsconfig file, not the workspace outdir', () => {
+    // When a tsconfig lives in a subdirectory of the workspace, the project
+    // reference path must be computed relative to that tsconfig file's own
+    // directory, otherwise the relative path is missing a `..` segment.
+    const dep = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep' });
+    const consumer = new yarn.TypeScriptWorkspace({
+      parent,
+      name: '@scope/consumer',
+      tsconfigDev: { fileName: 'config/tsconfig.dev.json' },
+    });
+
+    consumer.addWorkspaceDep(dep);
+
+    const outdir = Testing.synth(parent);
+
+    // Root tsconfig.json sits at the workspace root -> single `..`
+    const tsconfig = outdir['packages/@scope/consumer/tsconfig.json'];
+    expect(tsconfig.references).toContainEqual({ path: '../dep' });
+
+    // Dev tsconfig sits one directory deeper -> needs an extra `..`
+    const tsconfigDev = outdir['packages/@scope/consumer/config/tsconfig.dev.json'];
+    expect(tsconfigDev.references).toContainEqual({ path: '../../dep' });
+  });
+
   test('lazily added dev dep appears as exact in gather-versions', () => {
     const relParent = new yarn.CdkLabsMonorepo({
       name: 'monorepo',


### PR DESCRIPTION
When a workspace's tsconfig file lives in a subdirectory rather than at the workspace root, the generated TypeScript project reference paths were wrong. They were computed relative to the workspace `outdir`, but project references must be resolved relative to the tsconfig file that declares them. As a result a tsconfig placed in, for example, `config/tsconfig.dev.json` produced a reference path that was missing a `..` segment and pointed at the wrong package, which breaks `tsc --build`.

The reference path is now computed from the directory of each tsconfig file, so references are correct regardless of where the tsconfig lives. For the common case where the tsconfig sits at the workspace root the behavior is unchanged.

A regression test was added that configures a workspace with a dev tsconfig in a subdirectory and asserts both the root tsconfig (`../dep`) and the nested dev tsconfig (`../../dep`) get correct reference paths. The test fails against the previous logic and passes with this fix.
