### PR TITLE
fix(yarn): disable dev tsconfig for the monorepo root

### DIFF
--- a/src/yarn/monorepo.ts
+++ b/src/yarn/monorepo.ts
@@ -43,6 +43,13 @@ export class Monorepo extends typescript.TypeScriptProject {
       jest: false,
       eslint: false,
       release: false,
+      // The monorepo root is not a real compilation unit; its single tsconfig
+      // only exists to type-check the projenrc files and hold project
+      // references to the workspaces. A separate dev tsconfig is not just
+      // redundant, it actively resolves to `test/tsconfig.json` in projen and
+      // would pollute that file. Disabling it makes `tsconfigDev` alias
+      // `tsconfig`, consolidating everything onto the root `tsconfig.json`.
+      disableTsconfigDev: true,
     });
 
     Object.defineProperty(this, MONOREPO_SYM, { value: true });
@@ -70,7 +77,7 @@ export class Monorepo extends typescript.TypeScriptProject {
           parserOptions: {
             ecmaVersion: 2018,
             sourceType: 'module',
-            project: './tsconfig.dev.json',
+            project: `./${(this.tsconfigDev ?? this.tsconfig)?.fileName ?? 'tsconfig.json'}`,
           },
           ignorePatterns: ['!.projenrc.ts'],
           extends: ['plugin:prettier/recommended'],
@@ -252,9 +259,12 @@ export class Monorepo extends typescript.TypeScriptProject {
       }
     }
 
-    this.tsconfig?.file.addOverride('include', []);
-    this.tsconfigDev?.file.addOverride('include', ['.projenrc.ts', 'projenrc/**/*.ts']);
-    for (const tsconfig of [this.tsconfig, this.tsconfigDev]) {
+    // The root tsconfig is only there to type-check the projenrc files and to
+    // hold project references to the workspaces. Because the dev tsconfig is
+    // disabled, `tsconfigDev` aliases `tsconfig`, so we only have a single file
+    // to configure here (the `Set` dedupes in case that ever changes).
+    for (const tsconfig of new Set([this.tsconfig, this.tsconfigDev])) {
+      tsconfig?.file.addOverride('include', ['.projenrc.ts', 'projenrc/**/*.ts']);
       tsconfig?.file.addOverride(
         'references',
         this.subprojects.map((p) => ({ path: p.workspaceDirectory })),

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -208,7 +208,6 @@ exports[`CdkLabsMonorepo with a monorepo with indifferent settings synthesizes w
 /LICENSE linguist-generated
 /package.json linguist-generated
 /projenrc/tsconfig.json linguist-generated linguist-language=JSON-with-Comments
-/test/tsconfig.json linguist-generated linguist-language=JSON-with-Comments
 /tsconfig.json linguist-generated linguist-language=JSON-with-Comments
 /yarn.lock linguist-generated",
   ".github/pull_request_template.md": "Fixes #",
@@ -524,7 +523,6 @@ jspm_packages/
 !/.github/pull_request_template.md
 !/test/
 !/tsconfig.json
-!/test/tsconfig.json
 !/src/
 /lib
 /dist/
@@ -536,7 +534,6 @@ jspm_packages/
 /.projen/
 permissions-backup.acl
 /test/
-/test/tsconfig.json
 /src/
 !/lib/
 !/lib/**/*.js
@@ -597,7 +594,6 @@ tsconfig.tsbuildinfo
       ".projen/tasks.json",
       "LICENSE",
       "projenrc/tsconfig.json",
-      "test/tsconfig.json",
       "tsconfig.json",
     ],
   },
@@ -665,7 +661,7 @@ tsconfig.tsbuildinfo
         "name": "default",
         "steps": [
           {
-            "exec": "ts-node --project test/tsconfig.json .projenrc.ts",
+            "exec": "ts-node --project tsconfig.json .projenrc.ts",
           },
         ],
       },
@@ -2608,28 +2604,6 @@ tsconfig.tsbuildinfo
       "**/*.ts",
     ],
   },
-  "test/tsconfig.json": {
-    "compilerOptions": {
-      "noEmit": true,
-      "rootDir": "..",
-    },
-    "exclude": [
-      "node_modules",
-    ],
-    "extends": "../tsconfig.json",
-    "include": [
-      ".projenrc.ts",
-      "projenrc/**/*.ts",
-    ],
-    "references": [
-      {
-        "path": "packages/@cdklabs/one",
-      },
-      {
-        "path": "packages/@cdklabs/two",
-      },
-    ],
-  },
   "tsconfig.json": {
     "compilerOptions": {
       "alwaysStrict": true,
@@ -2664,7 +2638,10 @@ tsconfig.tsbuildinfo
     "exclude": [
       "node_modules",
     ],
-    "include": [],
+    "include": [
+      ".projenrc.ts",
+      "projenrc/**/*.ts",
+    ],
     "references": [
       {
         "path": "packages/@cdklabs/one",
@@ -3391,7 +3368,6 @@ exports[`CdkLabsMonorepo with monorepo that releases monorepo release 1`] = `
 /LICENSE linguist-generated
 /package.json linguist-generated
 /projenrc/tsconfig.json linguist-generated linguist-language=JSON-with-Comments
-/test/tsconfig.json linguist-generated linguist-language=JSON-with-Comments
 /tsconfig.json linguist-generated linguist-language=JSON-with-Comments
 /yarn.lock linguist-generated",
   ".github/pull_request_template.md": "Fixes #",
@@ -3979,7 +3955,6 @@ jspm_packages/
 !/.github/pull_request_template.md
 !/test/
 !/tsconfig.json
-!/test/tsconfig.json
 !/src/
 /lib
 /dist/
@@ -3992,7 +3967,6 @@ jspm_packages/
 /.projen/
 permissions-backup.acl
 /test/
-/test/tsconfig.json
 /src/
 !/lib/
 !/lib/**/*.js
@@ -4054,7 +4028,6 @@ tsconfig.tsbuildinfo
       ".projen/tasks.json",
       "LICENSE",
       "projenrc/tsconfig.json",
-      "test/tsconfig.json",
       "tsconfig.json",
     ],
   },
@@ -4122,7 +4095,7 @@ tsconfig.tsbuildinfo
         "name": "default",
         "steps": [
           {
-            "exec": "ts-node --project test/tsconfig.json .projenrc.ts",
+            "exec": "ts-node --project tsconfig.json .projenrc.ts",
           },
         ],
       },
@@ -6236,28 +6209,6 @@ tsconfig.tsbuildinfo
       "**/*.ts",
     ],
   },
-  "test/tsconfig.json": {
-    "compilerOptions": {
-      "noEmit": true,
-      "rootDir": "..",
-    },
-    "exclude": [
-      "node_modules",
-    ],
-    "extends": "../tsconfig.json",
-    "include": [
-      ".projenrc.ts",
-      "projenrc/**/*.ts",
-    ],
-    "references": [
-      {
-        "path": "packages/@cdklabs/one",
-      },
-      {
-        "path": "packages/@cdklabs/two",
-      },
-    ],
-  },
   "tsconfig.json": {
     "compilerOptions": {
       "alwaysStrict": true,
@@ -6292,7 +6243,10 @@ tsconfig.tsbuildinfo
     "exclude": [
       "node_modules",
     ],
-    "include": [],
+    "include": [
+      ".projenrc.ts",
+      "projenrc/**/*.ts",
+    ],
     "references": [
       {
         "path": "packages/@cdklabs/one",
@@ -6388,7 +6342,6 @@ exports[`CdkLabsMonorepo workspace inherits config from monorepo repository conf
 /LICENSE linguist-generated
 /package.json linguist-generated
 /projenrc/tsconfig.json linguist-generated linguist-language=JSON-with-Comments
-/test/tsconfig.json linguist-generated linguist-language=JSON-with-Comments
 /tsconfig.json linguist-generated linguist-language=JSON-with-Comments
 /yarn.lock linguist-generated",
   ".github/pull_request_template.md": "Fixes #",
@@ -6704,7 +6657,6 @@ jspm_packages/
 !/.github/pull_request_template.md
 !/test/
 !/tsconfig.json
-!/test/tsconfig.json
 !/src/
 /lib
 /dist/
@@ -6716,7 +6668,6 @@ jspm_packages/
 /.projen/
 permissions-backup.acl
 /test/
-/test/tsconfig.json
 /src/
 !/lib/
 !/lib/**/*.js
@@ -6777,7 +6728,6 @@ tsconfig.tsbuildinfo
       ".projen/tasks.json",
       "LICENSE",
       "projenrc/tsconfig.json",
-      "test/tsconfig.json",
       "tsconfig.json",
     ],
   },
@@ -6845,7 +6795,7 @@ tsconfig.tsbuildinfo
         "name": "default",
         "steps": [
           {
-            "exec": "ts-node --project test/tsconfig.json .projenrc.ts",
+            "exec": "ts-node --project tsconfig.json .projenrc.ts",
           },
         ],
       },
@@ -7998,25 +7948,6 @@ tsconfig.tsbuildinfo
       "**/*.ts",
     ],
   },
-  "test/tsconfig.json": {
-    "compilerOptions": {
-      "noEmit": true,
-      "rootDir": "..",
-    },
-    "exclude": [
-      "node_modules",
-    ],
-    "extends": "../tsconfig.json",
-    "include": [
-      ".projenrc.ts",
-      "projenrc/**/*.ts",
-    ],
-    "references": [
-      {
-        "path": "packages/@cdklabs/one",
-      },
-    ],
-  },
   "tsconfig.json": {
     "compilerOptions": {
       "alwaysStrict": true,
@@ -8051,7 +7982,10 @@ tsconfig.tsbuildinfo
     "exclude": [
       "node_modules",
     ],
-    "include": [],
+    "include": [
+      ".projenrc.ts",
+      "projenrc/**/*.ts",
+    ],
     "references": [
       {
         "path": "packages/@cdklabs/one",

--- a/test/cdklabs-monorepo.test.ts
+++ b/test/cdklabs-monorepo.test.ts
@@ -29,6 +29,32 @@ describe('CdkLabsMonorepo', () => {
       expect(outdir).toMatchSnapshot();
     });
 
+    test('does not generate a dev tsconfig at the root', () => {
+      const outdir = Testing.synth(parent);
+
+      expect(outdir['tsconfig.dev.json']).toBeUndefined();
+      // The projenrc include lives on the single root tsconfig.
+      expect(outdir['tsconfig.json'].include).toEqual(['.projenrc.ts', 'projenrc/**/*.ts']);
+    });
+
+    test('does not pollute the test tsconfig with projenrc include or workspace references', () => {
+      new yarn.TypeScriptWorkspace({ parent, name: '@cdklabs/one' });
+
+      const outdir = Testing.synth(parent);
+
+      // Previously the root "dev" tsconfig resolved to test/tsconfig.json, so
+      // the projenrc include and workspace references leaked into it. It should
+      // now be free of both (and is no longer generated at the root at all).
+      const testTsconfig = outdir['test/tsconfig.json'];
+      if (testTsconfig) {
+        expect(testTsconfig.include ?? []).not.toContain('.projenrc.ts');
+        expect(testTsconfig.references ?? []).toEqual([]);
+      }
+
+      // The workspace references live on the single root tsconfig instead.
+      expect(outdir['tsconfig.json'].references).toContainEqual({ path: 'packages/@cdklabs/one' });
+    });
+
     test('workspaces dont have their own projen dependency', () => {
       new yarn.TypeScriptWorkspace({
         parent,


### PR DESCRIPTION
The monorepo root is not a real compilation unit. Its single tsconfig only exists to type-check the projenrc files and to hold project references to the workspaces, so it never needed a separate development tsconfig.

Because no dev tsconfig was disabled, projen resolved `tsconfigDev` to `test/tsconfig.json`. As a result the projenrc `include` and the workspace `references` were written into the test tsconfig rather than the root tsconfig, and the generated projenrc task ran with `ts-node --project test/tsconfig.json`. Using the test configuration to drive project synthesis is incidental and surprising, and it left the root `tsconfig.json` with an empty `include`.

Disabling the dev tsconfig at the root makes `tsconfigDev` alias the main `tsconfig`, so everything is consolidated onto a single `tsconfig.json`. The projenrc include and the workspace references now live there, the projenrc task runs against it, and the spurious `test/tsconfig.json` is no longer generated. The prettier eslint config also now points at whichever tsconfig actually exists instead of a hardcoded `tsconfig.dev.json` that was never produced.

The snapshot change reflects exactly this consolidation, and new tests assert that no dev tsconfig is generated at the root, that the projenrc include lives on the root tsconfig, and that the test tsconfig is no longer polluted with projenrc include or workspace references.
