### PR TITLE
fix(yarn): test tsconfig missing self-reference in composite mode

### DIFF
--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -226,6 +226,28 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
       tsconfig?.file.addOverride('references', []);
     }
 
+    // Self-reference from the dev/test tsconfig to the main project tsconfig.
+    //
+    // By default the dev tsconfig lives in a subdirectory (e.g. `test/tsconfig.json`)
+    // and extends the main `tsconfig.json`. Under `composite: true`, TypeScript treats
+    // the dev tsconfig as a separate compilation unit with strict project boundaries:
+    // its `include` only covers files under its own directory. Test files that import
+    // from the parent `lib/` (`../lib/...`) are then reachable via imports but are not
+    // part of the dev project's file set, which fails with TS6307 on `tsc --build`.
+    //
+    // Adding a project reference from the dev tsconfig back to the directory of the main
+    // tsconfig tells TypeScript that the lib source is a separate, already-built project
+    // and to consume its declarations. We only do this when the two tsconfigs are not
+    // co-located (i.e. the dev tsconfig is not aliased to / sitting next to the main one).
+    if (this.tsconfig && this.tsconfigDev && this.tsconfig !== this.tsconfigDev) {
+      const mainTsconfigDir = dirname(this.tsconfig.file.absolutePath);
+      const devTsconfigDir = dirname(this.tsconfigDev.file.absolutePath);
+      const selfReference = relative(devTsconfigDir, mainTsconfigDir);
+      if (selfReference !== '') {
+        this.tsconfigDev.file.addToArray('references', { path: selfReference });
+      }
+    }
+
     // Add workspace references
     for (const dep of options.deps?.filter(isWorkspaceReference) ?? []) {
       this.addWorkspaceDep(dep, DependencyType.RUNTIME);

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -1751,7 +1751,11 @@ tsconfig.tsbuildinfo
     "include": [
       "**/*.ts",
     ],
-    "references": [],
+    "references": [
+      {
+        "path": "..",
+      },
+    ],
   },
   "packages/@cdklabs/one/tsconfig.json": {
     "compilerOptions": {
@@ -2548,7 +2552,11 @@ tsconfig.tsbuildinfo
     "include": [
       "**/*.ts",
     ],
-    "references": [],
+    "references": [
+      {
+        "path": "..",
+      },
+    ],
   },
   "packages/@cdklabs/two/tsconfig.json": {
     "compilerOptions": {
@@ -5283,7 +5291,11 @@ tsconfig.tsbuildinfo
     "include": [
       "**/*.ts",
     ],
-    "references": [],
+    "references": [
+      {
+        "path": "..",
+      },
+    ],
   },
   "packages/@cdklabs/one/tsconfig.json": {
     "compilerOptions": {
@@ -6153,7 +6165,11 @@ tsconfig.tsbuildinfo
     "include": [
       "**/*.ts",
     ],
-    "references": [],
+    "references": [
+      {
+        "path": "..",
+      },
+    ],
   },
   "packages/@cdklabs/two/tsconfig.json": {
     "compilerOptions": {
@@ -7892,7 +7908,11 @@ tsconfig.tsbuildinfo
     "include": [
       "**/*.ts",
     ],
-    "references": [],
+    "references": [
+      {
+        "path": "..",
+      },
+    ],
   },
   "packages/@cdklabs/one/tsconfig.json": {
     "compilerOptions": {

--- a/test/add-workspace-dep.test.ts
+++ b/test/add-workspace-dep.test.ts
@@ -162,6 +162,57 @@ describe('addWorkspaceDep', () => {
     expect(tsconfigDev.references).toContainEqual({ path: '../../dep' });
   });
 
+  test('dev tsconfig in a subdirectory gets a self-reference to the main project', () => {
+    // By default the dev tsconfig lives at `test/tsconfig.json` and extends the main
+    // `tsconfig.json` with `composite: true`. Without a project reference back to the
+    // main project, test files importing from `../lib` fail with TS6307. The dev tsconfig
+    // must reference the directory of the main tsconfig (one level up).
+    const ws = new yarn.TypeScriptWorkspace({ parent, name: '@scope/lib' });
+
+    const outdir = Testing.synth(parent);
+
+    const tsconfigDev = outdir['packages/@scope/lib/test/tsconfig.json'];
+    expect(tsconfigDev.references).toContainEqual({ path: '..' });
+
+    // The main tsconfig must NOT reference itself.
+    const tsconfig = outdir['packages/@scope/lib/tsconfig.json'];
+    expect(tsconfig.references).toEqual([]);
+    void ws;
+  });
+
+  test('self-reference is combined with workspace references in the dev tsconfig', () => {
+    const dep = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep' });
+    const consumer = new yarn.TypeScriptWorkspace({ parent, name: '@scope/consumer' });
+
+    consumer.addWorkspaceDep(dep, DependencyType.BUILD);
+
+    const outdir = Testing.synth(parent);
+
+    // Dev tsconfig sits in `test/`, so it needs both the self-reference (`..`)
+    // and the workspace dep reference (`../../dep`).
+    const tsconfigDev = outdir['packages/@scope/consumer/test/tsconfig.json'];
+    expect(tsconfigDev.references).toContainEqual({ path: '..' });
+    expect(tsconfigDev.references).toContainEqual({ path: '../../dep' });
+  });
+
+  test('co-located dev tsconfig does not get a self-reference', () => {
+    // When the dev tsconfig lives next to the main tsconfig (workspace root), there is
+    // no project boundary to cross, so no self-reference should be added (an empty path
+    // reference would be invalid).
+    const ws = new yarn.TypeScriptWorkspace({
+      parent,
+      name: '@scope/lib',
+      tsconfigDevFile: 'tsconfig.dev.json',
+    });
+
+    const outdir = Testing.synth(parent);
+
+    const tsconfigDev = outdir['packages/@scope/lib/tsconfig.dev.json'];
+    expect(tsconfigDev.references).not.toContainEqual({ path: '' });
+    expect(tsconfigDev.references).not.toContainEqual({ path: '.' });
+    void ws;
+  });
+
   test('lazily added dev dep appears as exact in gather-versions', () => {
     const relParent = new yarn.CdkLabsMonorepo({
       name: 'monorepo',


### PR DESCRIPTION
By default every `TypeScriptWorkspace` generates its dev/test tsconfig at `test/tsconfig.json`, extending the main `tsconfig.json` with `composite: true`. Composite mode makes TypeScript enforce strict project boundaries: the dev tsconfig's `include` only covers files under its own directory. Because test files routinely import from the parent `lib/`, those sources are reachable through imports but are not part of the dev project's own file set, so `tsc --build` fails with TS6307 ("File ... is not listed within the file list of project ...").

The reason this happens is that the dev tsconfig was given an empty `references` array and never pointed back at the project that actually compiles the lib sources. Composite projects are expected to declare references to the other compilation units they depend on, and the dev tsconfig depends on the main project.

This adds a project reference from the dev tsconfig to the directory of the main tsconfig, which tells TypeScript the lib source is a separate, already-built project and to consume its declarations rather than treating those files as orphaned members of the test project. The reference is computed relative to the dev tsconfig's own location so it stays correct regardless of how deep the file is nested, and it is only added when the two tsconfigs are not co-located. That guard matters because the dev tsconfig can be aliased to the main tsconfig (or configured to sit next to it), and emitting a self-reference with an empty path in that case would itself be invalid.

For the common default layout this means `test/tsconfig.json` now carries `{ "path": ".." }`, while the main `tsconfig.json` is left untouched.

Fixes #
