### PR TITLE
fix(yarn): test type-check hides @internal members of the library

### DIFF
--- a/src/yarn/typescript-workspace.ts
+++ b/src/yarn/typescript-workspace.ts
@@ -226,27 +226,6 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
       tsconfig?.file.addOverride('references', []);
     }
 
-    // Self-reference from the dev/test tsconfig to the main project tsconfig.
-    //
-    // By default the dev tsconfig lives in a subdirectory (e.g. `test/tsconfig.json`)
-    // and extends the main `tsconfig.json`. Under `composite: true`, TypeScript treats
-    // the dev tsconfig as a separate compilation unit with strict project boundaries:
-    // its `include` only covers files under its own directory. Test files that import
-    // from the parent `lib/` (`../lib/...`) are then reachable via imports but are not
-    // part of the dev project's file set, which fails with TS6307 on `tsc --build`.
-    //
-    // Adding a project reference from the dev tsconfig back to the directory of the main
-    // tsconfig tells TypeScript that the lib source is a separate, already-built project
-    // and to consume its declarations. We only do this when the two tsconfigs are not
-    // co-located (i.e. the dev tsconfig is not aliased to / sitting next to the main one).
-    if (this.tsconfig && this.tsconfigDev && this.tsconfig !== this.tsconfigDev) {
-      const mainTsconfigDir = dirname(this.tsconfig.file.absolutePath);
-      const devTsconfigDir = dirname(this.tsconfigDev.file.absolutePath);
-      const selfReference = relative(devTsconfigDir, mainTsconfigDir);
-      if (selfReference !== '') {
-        this.tsconfigDev.file.addToArray('references', { path: selfReference });
-      }
-    }
 
     // Add workspace references
     for (const dep of options.deps?.filter(isWorkspaceReference) ?? []) {
@@ -385,7 +364,56 @@ export class TypeScriptWorkspace extends typescript.TypeScriptProject implements
 
   public preSynthesize(): void {
     super.preSynthesize();
+    this.typecheckTestsAgainstLibrarySource();
     this.validateNoPrivateWorkspaceDeps();
+  }
+
+  /**
+   * Type-check tests against the library *source* rather than its emitted declarations.
+   *
+   * The dev/test tsconfig is a separate `composite` project, so it doesn't see the library
+   * source by default. Rather than referencing the main project (which would consume its
+   * `stripInternal`'d declarations and hide `@internal` members from tests under `tsc --build`),
+   * we mirror the main project's `include` into the test program, path-adjusted to the test dir.
+   *
+   * Excludes are only mirrored when they target the source dir (`src/...`): a `src/`-prefixed
+   * pattern can only match source files, so it can never drop a test file the test build owns
+   * (e.g. `test/.../integ.*.ts`, which the library build excludes but the test build must keep).
+   *
+   * Runs at `preSynthesize` since the main tsconfig's patterns may be modified after construction.
+   */
+  private typecheckTestsAgainstLibrarySource(): void {
+    const mainTsconfig = this.tsconfig;
+    const testTsconfig = this.tsconfigDev;
+
+    // When the dev tsconfig is disabled it aliases the main one (`tsconfig === tsconfigDev`),
+    // so there is nothing to wire up.
+    if (!mainTsconfig || !testTsconfig || mainTsconfig === testTsconfig) {
+      return;
+    }
+
+    // The relative path from the test tsconfig directory to the main tsconfig directory
+    // (e.g. `..`). When the two are co-located there is no project boundary to cross and the
+    // library source is already part of the test program's file set, so there is nothing to do.
+    const toMain = relative(dirname(testTsconfig.file.absolutePath), dirname(mainTsconfig.file.absolutePath));
+    if (toMain === '') {
+      return;
+    }
+
+    // Compile the same set of library source files as the main build, so `@internal` members
+    // remain visible. The main tsconfig's patterns are relative to the package root; the test
+    // tsconfig lives one directory deeper, so prefix them with the path back to the main dir.
+    const srcPrefix = `${this.srcdir}/`;
+    for (const pattern of mainTsconfig.include) {
+      testTsconfig.addInclude(`${toMain}/${pattern}`);
+    }
+    // Only mirror excludes that target the source directory; test-directory excludes belong to
+    // the library build alone (see above).
+    for (const pattern of mainTsconfig.exclude) {
+      if (pattern.startsWith(srcPrefix)) {
+        testTsconfig.addExclude(`${toMain}/${pattern}`);
+      }
+    }
   }
 
   private validateNoPrivateWorkspaceDeps(): void {

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -1750,12 +1750,9 @@ tsconfig.tsbuildinfo
     "extends": "../tsconfig.json",
     "include": [
       "**/*.ts",
+      "../src/**/*.ts",
     ],
-    "references": [
-      {
-        "path": "..",
-      },
-    ],
+    "references": [],
   },
   "packages/@cdklabs/one/tsconfig.json": {
     "compilerOptions": {
@@ -2551,12 +2548,9 @@ tsconfig.tsbuildinfo
     "extends": "../tsconfig.json",
     "include": [
       "**/*.ts",
+      "../src/**/*.ts",
     ],
-    "references": [
-      {
-        "path": "..",
-      },
-    ],
+    "references": [],
   },
   "packages/@cdklabs/two/tsconfig.json": {
     "compilerOptions": {
@@ -5290,12 +5284,9 @@ tsconfig.tsbuildinfo
     "extends": "../tsconfig.json",
     "include": [
       "**/*.ts",
+      "../src/**/*.ts",
     ],
-    "references": [
-      {
-        "path": "..",
-      },
-    ],
+    "references": [],
   },
   "packages/@cdklabs/one/tsconfig.json": {
     "compilerOptions": {
@@ -6164,12 +6155,9 @@ tsconfig.tsbuildinfo
     "extends": "../tsconfig.json",
     "include": [
       "**/*.ts",
+      "../src/**/*.ts",
     ],
-    "references": [
-      {
-        "path": "..",
-      },
-    ],
+    "references": [],
   },
   "packages/@cdklabs/two/tsconfig.json": {
     "compilerOptions": {
@@ -7907,12 +7895,9 @@ tsconfig.tsbuildinfo
     "extends": "../tsconfig.json",
     "include": [
       "**/*.ts",
+      "../src/**/*.ts",
     ],
-    "references": [
-      {
-        "path": "..",
-      },
-    ],
+    "references": [],
   },
   "packages/@cdklabs/one/tsconfig.json": {
     "compilerOptions": {

--- a/test/add-workspace-dep.test.ts
+++ b/test/add-workspace-dep.test.ts
@@ -162,17 +162,23 @@ describe('addWorkspaceDep', () => {
     expect(tsconfigDev.references).toContainEqual({ path: '../../dep' });
   });
 
-  test('dev tsconfig in a subdirectory gets a self-reference to the main project', () => {
+  test('dev tsconfig compiles the library source instead of self-referencing the main project', () => {
     // By default the dev tsconfig lives at `test/tsconfig.json` and extends the main
-    // `tsconfig.json` with `composite: true`. Without a project reference back to the
-    // main project, test files importing from `../lib` fail with TS6307. The dev tsconfig
-    // must reference the directory of the main tsconfig (one level up).
+    // `tsconfig.json` with `composite: true`. To type-check tests against the library
+    // *source* (so `@internal` members remain visible under `tsc --build`), the dev tsconfig
+    // must NOT reference the main project's `stripInternal`'d declarations. Instead it mirrors
+    // the main project's `include`/`exclude` patterns, path-adjusted one directory up.
     const ws = new yarn.TypeScriptWorkspace({ parent, name: '@scope/lib' });
 
     const outdir = Testing.synth(parent);
 
     const tsconfigDev = outdir['packages/@scope/lib/test/tsconfig.json'];
-    expect(tsconfigDev.references).toContainEqual({ path: '..' });
+    // No self-reference to the main project.
+    expect(tsconfigDev.references).not.toContainEqual({ path: '..' });
+    // The library source is compiled as part of the test program.
+    expect(tsconfigDev.include).toContain('../src/**/*.ts');
+    // The main project's non-source excludes (e.g. `node_modules`) are NOT mirrored.
+    expect(tsconfigDev.exclude).not.toContain('../node_modules');
 
     // The main tsconfig must NOT reference itself.
     const tsconfig = outdir['packages/@scope/lib/tsconfig.json'];
@@ -180,7 +186,23 @@ describe('addWorkspaceDep', () => {
     void ws;
   });
 
-  test('self-reference is combined with workspace references in the dev tsconfig', () => {
+  test('only source-directory excludes are mirrored into the dev tsconfig', () => {
+    const ws = new yarn.TypeScriptWorkspace({ parent, name: '@scope/lib' });
+    // A source-targeted exclude must be mirrored: the file is not valid standalone TS and
+    // should be kept out of both the library and the test build.
+    ws.tsconfig!.addExclude('src/init-templates/**/*.template.ts');
+    // A test-targeted exclude must NOT be mirrored: the test build owns the test tree, and the
+    // library build only excludes it to keep test files out of the library compilation.
+    ws.tsconfig!.addExclude('test/language-tests/**/integ.*.ts');
+
+    const outdir = Testing.synth(parent);
+
+    const tsconfigDev = outdir['packages/@scope/lib/test/tsconfig.json'];
+    expect(tsconfigDev.exclude).toContain('../src/init-templates/**/*.template.ts');
+    expect(tsconfigDev.exclude).not.toContain('../test/language-tests/**/integ.*.ts');
+  });
+
+  test('workspace references are kept while the library source is compiled into the dev tsconfig', () => {
     const dep = new yarn.TypeScriptWorkspace({ parent, name: '@scope/dep' });
     const consumer = new yarn.TypeScriptWorkspace({ parent, name: '@scope/consumer' });
 
@@ -188,17 +210,19 @@ describe('addWorkspaceDep', () => {
 
     const outdir = Testing.synth(parent);
 
-    // Dev tsconfig sits in `test/`, so it needs both the self-reference (`..`)
-    // and the workspace dep reference (`../../dep`).
     const tsconfigDev = outdir['packages/@scope/consumer/test/tsconfig.json'];
-    expect(tsconfigDev.references).toContainEqual({ path: '..' });
+    // No self-reference to the main project ...
+    expect(tsconfigDev.references).not.toContainEqual({ path: '..' });
+    // ... but the workspace dep reference is preserved.
     expect(tsconfigDev.references).toContainEqual({ path: '../../dep' });
+    // ... and the library source is compiled into the test program.
+    expect(tsconfigDev.include).toContain('../src/**/*.ts');
   });
 
-  test('co-located dev tsconfig does not get a self-reference', () => {
-    // When the dev tsconfig lives next to the main tsconfig (workspace root), there is
-    // no project boundary to cross, so no self-reference should be added (an empty path
-    // reference would be invalid).
+  test('co-located dev tsconfig does not mirror the library source', () => {
+    // When the dev tsconfig lives next to the main tsconfig (workspace root), there is no
+    // project boundary to cross: the library source is already part of its file set, so no
+    // path-adjusted include/exclude is added and no self-reference exists.
     const ws = new yarn.TypeScriptWorkspace({
       parent,
       name: '@scope/lib',
@@ -210,6 +234,7 @@ describe('addWorkspaceDep', () => {
     const tsconfigDev = outdir['packages/@scope/lib/tsconfig.dev.json'];
     expect(tsconfigDev.references).not.toContainEqual({ path: '' });
     expect(tsconfigDev.references).not.toContainEqual({ path: '.' });
+    expect(tsconfigDev.include).not.toContain('../src/**/*.ts');
     void ws;
   });
 


### PR DESCRIPTION
Tests that legitimately reach into `@internal` members of their own library failed to type-check under `tsc --build`, reporting errors like `Property '_foo' does not exist`. This happened because the dev/test tsconfig is a separate `composite` project that referenced the main project, and under `tsc --build` a referenced project is consumed through its emitted declarations. Those declarations are produced with `stripInternal: true`, so anything marked `@internal` disappeared from the tests' view. The editor never showed this because its language service reads the referenced project's source directly.

Rather than referencing the main project's stripped declarations, the test program now compiles the library source itself: we mirror the main tsconfig's `include` patterns into the test tsconfig (path-adjusted to the test directory). This keeps `@internal` members visible and makes `tsc --build` behave like the editor and like the old combined `lib + test` tsconfig. We mirror the actual `include` patterns instead of a blanket glob because packages deliberately shape their compilation, for example excluding `cdk init` `%name%.template.ts` placeholders that are not valid standalone TypeScript, or including JSON imported via `resolveJsonModule`.

Excludes are mirrored only when they target the source directory (`src/...`). The main project's excludes serve two different intents: keeping non-source files out of compilation (which applies to both builds) and keeping test files out of the library build (which applies only to the library build). A `src/`-prefixed pattern can only ever match source files, so it can never drop a file from the test tree that the test build owns and must lint — such as `test/.../integ.*.ts`, which the library build excludes but the test build is responsible for. Restricting to source-targeted excludes gives that as a structural guarantee.

This replaces the self-reference approach introduced in #949. The mirroring runs at `preSynthesize` because a package's `.projenrc` commonly adjusts the main tsconfig's `include`/`exclude` after the workspace is constructed.

Fixes #
