### PR TITLE
fix(yarn): fail loud when gather-versions reads a 0.0.0 placeholder dependency

### DIFF
--- a/src/yarn/gather-versions.exec.ts
+++ b/src/yarn/gather-versions.exec.ts
@@ -18,6 +18,10 @@ export function main(argv: string[], packageDirectory: string) {
 
   const isReset = process.env.RESET_VERSIONS === 'true';
 
+  // Set to 'true' by the monorepo release task while it bumps and builds packages.
+  // Used to enforce the guard below only during a real release (not local dev/synth).
+  const isRelease = process.env.RELEASE === 'true';
+
   const deps = Object.fromEntries(argv.map(x => x.split('=', 2) as [string, string]));
 
   // The PJ file we are updating
@@ -31,6 +35,24 @@ export function main(argv: string[], packageDirectory: string) {
 
   for (const [dep, depType] of Object.entries(deps)) {
     const depVersion = dependencyInfo(dep, packageDirectory).version;
+
+    // A dependency that still resolves to the 0.0.0 placeholder was not versioned before this
+    // package gathered its dependency ranges: the dependency's bump task did not run (it was skipped
+    // or failed), so its package.json still holds the projen 0.0.0 placeholder. Writing a range off
+    // 0.0.0 publishes a broken '^0.0.0' (or '0.0.0'/'~0.0.0'/'>=0.0.0') dependency that npm resolves
+    // to the ancient 0.0.0 artifact. Fail loudly instead of publishing it. Only enforced for
+    // runtime/peer dependencies declared on this package, and only during a release, so local
+    // dev/synth and the reset (unbump) path are unaffected.
+    const isRuntimeOrPeerDep = Boolean(manifest.dependencies?.[dep]) || Boolean(manifest.peerDependencies?.[dep]);
+    if (isRelease && !isReset && isRuntimeOrPeerDep && depVersion === '0.0.0') {
+      throw new Error(
+        `gather-versions: dependency '${dep}' of '${manifest.name}' resolved to the placeholder version 0.0.0. ` +
+        `Its bump task did not run before '${manifest.name}' gathered versions (skipped or failed), so publishing ` +
+        'now would ship a broken \'^0.0.0\' range. Re-run the release; if it recurs, check why the bump task for ' +
+        `'${dep}' was skipped (see its task condition).`,
+      );
+    }
+
     const rangeVersion = versionForRange(depType, depVersion);
 
     const dependencyClasses = [

--- a/test/gather-versions.test.ts
+++ b/test/gather-versions.test.ts
@@ -87,6 +87,92 @@ test('if RESET_VERSIONS is true, gather-versions ignores command line and revert
   });
 });
 
+test('during a release, gather-versions refuses to write a 0.0.0-based range for a runtime dependency', async () => {
+  await withTempDir(async (dir) => {
+    await writeJsonFiles(dir, {
+      'node_modules/depA/package.json': {
+        name: 'depA',
+        version: '0.0.0', // un-bumped placeholder: depA was not versioned before this package
+      },
+      'package.json': {
+        name: 'root',
+        dependencies: {
+          depA: '^0.0.0',
+        },
+      },
+    });
+
+    // WHEN / THEN
+    process.env.RELEASE = 'true';
+    try {
+      expect(() => main(['depA=future-minor'], dir)).toThrow(/dependency 'depA' of 'root' resolved to the placeholder version 0\.0\.0/);
+    } finally {
+      delete process.env.RELEASE;
+    }
+
+    // AND the package.json is left untouched (we failed before writing)
+    expect(JSON.parse(await fs.readFile(path.join(dir, 'package.json'), 'utf-8')).dependencies.depA).toEqual('^0.0.0');
+  });
+});
+
+test('outside a release, a 0.0.0 dependency version is tolerated (no throw)', async () => {
+  await withTempDir(async (dir) => {
+    await writeJsonFiles(dir, {
+      'node_modules/depA/package.json': {
+        name: 'depA',
+        version: '0.0.0',
+      },
+      'package.json': {
+        name: 'root',
+        dependencies: {
+          depA: '^0.0.0',
+        },
+      },
+    });
+
+    // WHEN (RELEASE is not set)
+    expect(() => main(['depA=future-minor'], dir)).not.toThrow();
+
+    // THEN it passes the placeholder through as before
+    expect(JSON.parse(await fs.readFile(path.join(dir, 'package.json'), 'utf-8')).dependencies.depA).toEqual('^0.0.0');
+  });
+});
+
+test('during a release, gather-versions refuses when multiple runtime dependencies are 0.0.0 (fails on the first)', async () => {
+  await withTempDir(async (dir) => {
+    await writeJsonFiles(dir, {
+      'node_modules/depA/package.json': {
+        name: 'depA',
+        version: '0.0.0', // both dependencies un-bumped
+      },
+      'node_modules/depB/package.json': {
+        name: 'depB',
+        version: '0.0.0',
+      },
+      'package.json': {
+        name: 'root',
+        dependencies: {
+          depA: '^0.0.0',
+          depB: '^0.0.0',
+        },
+      },
+    });
+
+    // WHEN / THEN: it aborts deterministically on the first gathered dependency (depA)
+    process.env.RELEASE = 'true';
+    try {
+      expect(() => main(['depA=future-minor', 'depB=future-minor'], dir)).toThrow(/dependency 'depA' of 'root' resolved to the placeholder version 0\.0\.0/);
+    } finally {
+      delete process.env.RELEASE;
+    }
+
+    // AND neither range was written: the guard aborts before mutating package.json
+    const written = JSON.parse(await fs.readFile(path.join(dir, 'package.json'), 'utf-8'));
+    expect(written.dependencies.depA).toEqual('^0.0.0');
+    expect(written.dependencies.depB).toEqual('^0.0.0');
+  });
+});
+
 const NO_DEVDEPS: Partial<TypeScriptWorkspaceOptions> = {
   // We're actually installing these, so cut down on deps
   jest: false,


### PR DESCRIPTION
### What broke

`@aws-cdk/service-spec-importers@0.0.133` was published depending on `@aws-cdk/service-spec-types: "^0.0.0"` and `@cdklabs/tskb: "^0.0.0"` (verify: `npm view @aws-cdk/service-spec-importers@0.0.133 dependencies`; the prior `0.0.132` correctly declared `^0.0.251`). npm resolves `^0.0.0` to exactly `0.0.0`, so consumers install an ancient stub and downstream builds break. This took down the aws-cdk "AWS Service Spec Update" workflow: https://github.com/aws/aws-cdk/actions/runs/28980496350.

### Cause

`gather-versions` writes each runtime/peer dependency range from the dependency's on-disk workspace `package.json` version. During a monorepo release each package's real version is materialized by its own bump task. If a dependency's bump task does not run (it was skipped or failed), its `package.json` still holds the projen `0.0.0` placeholder, so `gather-versions` silently emits `^0.0.0`. In the 0.0.133 release the type/tskb bump tasks were skipped while importers' bump ran, so importers published `^0.0.0`. The release log shows it directly: https://github.com/cdklabs/awscdk-service-spec/actions/runs/28693317594 logs `Updated versions { ... "@aws-cdk/service-spec-types": "^0.0.0", "@cdklabs/tskb": "^0.0.0" }` for importers.

### The fix

Fail loud instead of publishing a broken range. During a release (`RELEASE=true`, and not the reset/unbump path), if a declared runtime or peer intra-repo dependency resolves to `0.0.0`, throw with a message that points at the skipped bump task, rather than writing the range. This aborts the release so the problem is caught and re-run instead of silently shipping an uninstallable range. Local dev, synth, and the reset path are unaffected.

Why a guard rather than a tag/registry fallback: `gather-versions` is an offline build-time script; a fallback would silently mask a skipped bump and would still need a fail path on a package's first release. The guard is deterministic and surfaces the real problem.

### Validation

- New tests: throws during a release on a `0.0.0` runtime dependency (and leaves `package.json` untouched); tolerated outside a release; aborts deterministically on the first of two `0.0.0` dependencies.
- Full unit suite green; eslint clean.

### Related PRs

- This PR is the consumer-side fail-loud guard.
- Companion in this repo, which removes the intermittent skip that leaves the placeholder in place: https://github.com/cdklabs/cdklabs-projen-project-types/pull/961
- Upstream projen root-cause fix (the piped `grep -q` condition): https://github.com/projen/projen/pull/4819