### PR TITLE
fix(yarn): make the release bump phase resilient to the intermittent projen condition skip

### DIFF
--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -237,7 +237,18 @@ export class MonorepoRelease extends Component {
     // Unroll out the 'release' task, and do all the phases for each individual package. We need to 'bump' at the same
     // time so that the dependency versions in all 'package.json's are correct.
     this.releaseTask.exec(`${this.wsRun} shx rm -rf dist`);
-    this.releaseTask.exec(`${this.wsRun} bump`);
+    // Retry the bump phase exactly once. The per-package bump condition can
+    // intermittently skip under projen's shell (see the system-shell change on
+    // this task and the projen issue); a single retry turns that transient skip
+    // into a success. Bump is idempotent: each package's own version recomputes
+    // from its git tag, and versions materialized in the first pass persist into
+    // the second, so the retry cannot double-bump. A second failure still exits
+    // non-zero and aborts the release (surfacing the gather-versions guard error
+    // if a placeholder was the cause). POSIX form; runs under the system shell
+    // set above. Scope is deliberately limited to the bump step.
+    this.releaseTask.exec(
+      `${this.wsRun} bump || { echo 'release: bump phase failed, retrying once (bump is idempotent: versions recompute from git tags and first-pass versions persist)'; ${this.wsRun} bump; }`,
+    );
     if (this.buildWithNx) {
       this.releaseTask.exec('nx run-many -t build');
       this.releaseTask.env('NX_SKIP_NX_CACHE', 'true');

--- a/src/yarn/monorepo-release.ts
+++ b/src/yarn/monorepo-release.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { DependencyType, github, release as projenRelease, Component, Project, Task } from 'projen';
+import { DependencyType, github, release as projenRelease, Component, Project, Task, TaskShell } from 'projen';
 import { BUILD_ARTIFACT_NAME, PERMISSION_BACKUP_FILE } from 'projen/lib/github/constants';
 import { MonorepoReleaseOptions } from './monorepo-release-options';
 import { TypeScriptWorkspace } from './typescript-workspace';
@@ -227,6 +227,13 @@ export class MonorepoRelease extends Component {
       description: 'Prepare a release from all monorepo packages',
       env,
     });
+    // Match the per-package bump task: run the release task through the system
+    // shell rather than projen's built-in dax shell. projen conditions and step
+    // commands are evaluated with the task's resolved shell (projen
+    // cli/task-runtime.js:261). This task has no `CHANGES_SINCE_LAST_RELEASE`
+    // condition today, so this is defense in depth and keeps the release
+    // orchestration on the same shell as the bump tasks it drives.
+    this.releaseTask.shell = TaskShell.system();
     // Unroll out the 'release' task, and do all the phases for each individual package. We need to 'bump' at the same
     // time so that the dependency versions in all 'package.json's are correct.
     this.releaseTask.exec(`${this.wsRun} shx rm -rf dist`);

--- a/src/yarn/typescript-workspace-release.ts
+++ b/src/yarn/typescript-workspace-release.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import { Component, ReleasableCommits, Task, Version, VersionBranchOptions, release } from 'projen';
+import { Component, ReleasableCommits, Task, TaskShell, Version, VersionBranchOptions, release } from 'projen';
 import { GatherVersions, GatherVersionsOptions } from './gather-versions.task';
 import { TypeScriptWorkspace } from './typescript-workspace';
 
@@ -90,6 +90,20 @@ export class WorkspaceRelease extends Component {
     });
 
     const bumpTask = this.obtainBumpTask();
+    // Run the bump task (and therefore its `CHANGES_SINCE_LAST_RELEASE` condition)
+    // through the system shell instead of projen's built-in dax shell. projen
+    // evaluates a task's condition with the task's resolved shell (see projen
+    // cli/task-runtime.js:261). Under dax the condition `git log --oneline -1 |
+    // grep -qv "chore(release):"` is racy: `grep -q` closes the pipe after the
+    // first line and dax fails writing the rest of `git log`'s output
+    // ("WritableStream is closed"), which dax surfaces as a non-zero exit that is
+    // indistinguishable from a legitimate "skip". The task is then skipped, its
+    // version is never materialized, and dependents publish a broken `^0.0.0`
+    // range. The system shell follows POSIX pipeline semantics (the status is
+    // grep's, SIGPIPE on the upstream is benign), so the condition is evaluated
+    // reliably. This is a workaround for the upstream projen defect; remove it
+    // once projen makes the condition robust.
+    bumpTask.shell = TaskShell.system();
     bumpTask.prependSpawn(gatherVersions);
     // The bumpTask needs to be executed with environment variables that control
     // version information. These are not part of the upstream task itself yet,

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -118,7 +118,7 @@ exports[`CdkLabsMonorepo nx integration can build with nx 2`] = `
       "exec": "yarn workspaces run shx rm -rf dist",
     },
     {
-      "exec": "yarn workspaces run bump",
+      "exec": "yarn workspaces run bump || { echo 'release: bump phase failed, retrying once (bump is idempotent: versions recompute from git tags and first-pass versions persist)'; yarn workspaces run bump; }",
     },
     {
       "exec": "nx run-many -t build",
@@ -4207,7 +4207,7 @@ tsconfig.tsbuildinfo
             "exec": "yarn workspaces run shx rm -rf dist",
           },
           {
-            "exec": "yarn workspaces run bump",
+            "exec": "yarn workspaces run bump || { echo 'release: bump phase failed, retrying once (bump is idempotent: versions recompute from git tags and first-pass versions persist)'; yarn workspaces run bump; }",
           },
           {
             "exec": "yarn workspaces run build",

--- a/test/__snapshots__/cdklabs-monorepo.test.ts.snap
+++ b/test/__snapshots__/cdklabs-monorepo.test.ts.snap
@@ -112,6 +112,7 @@ exports[`CdkLabsMonorepo nx integration can build with nx 2`] = `
     "RELEASE": "true",
   },
   "name": "release",
+  "shell": "system",
   "steps": [
     {
       "exec": "yarn workspaces run shx rm -rf dist",
@@ -4200,6 +4201,7 @@ tsconfig.tsbuildinfo
           "RELEASE": "true",
         },
         "name": "release",
+        "shell": "system",
         "steps": [
           {
             "exec": "yarn workspaces run shx rm -rf dist",
@@ -4873,6 +4875,7 @@ tsconfig.tsbuildinfo
           "VERSIONRCOPTIONS": "{"path":"."}",
         },
         "name": "bump",
+        "shell": "system",
         "steps": [
           {
             "spawn": "gather-versions",
@@ -5787,6 +5790,7 @@ tsconfig.tsbuildinfo
           "VERSIONRCOPTIONS": "{"path":"."}",
         },
         "name": "bump",
+        "shell": "system",
         "steps": [
           {
             "spawn": "gather-versions",

--- a/test/bump-condition-shell.test.ts
+++ b/test/bump-condition-shell.test.ts
@@ -1,0 +1,35 @@
+import { Testing } from 'projen/lib/testing';
+import { yarn } from '../src';
+
+// The per-package `bump` task keeps projen's `CHANGES_SINCE_LAST_RELEASE`
+// condition (`git log --oneline -1 | grep -qv "chore(release):"`). projen
+// evaluates that condition with the task's resolved shell (projen
+// cli/task-runtime.js:261). Under projen's built-in dax shell the pipe is racy
+// and can spuriously skip the task, leaving a 0.0.0 placeholder that dependents
+// then publish as a broken `^0.0.0` range. Running the task through the system
+// shell evaluates the condition reliably. These tests assert the generated task
+// manifests carry the system shell.
+describe('bump/release tasks run under the system shell', () => {
+  test('a release-enabled workspace bump task keeps the release condition and uses the system shell', () => {
+    const parent = new yarn.CdkLabsMonorepo({ name: 'monorepo', defaultReleaseBranch: 'main', release: true });
+    new yarn.TypeScriptWorkspace({ parent, name: '@cdklabs/one' });
+
+    const outdir = Testing.synth(parent);
+    const bump = outdir['packages/@cdklabs/one/.projen/tasks.json'].tasks.bump;
+
+    // Still gated by the release condition (we did not remove it) ...
+    expect(bump.condition).toMatch(/grep -qv "chore\(release\):"/);
+    // ... but the condition is now evaluated by the system shell, not dax.
+    expect(bump.shell).toEqual('system');
+  });
+
+  test('the monorepo root release task uses the system shell', () => {
+    const parent = new yarn.CdkLabsMonorepo({ name: 'monorepo', defaultReleaseBranch: 'main', release: true });
+    new yarn.TypeScriptWorkspace({ parent, name: '@cdklabs/one' });
+
+    const outdir = Testing.synth(parent);
+    const release = outdir['.projen/tasks.json'].tasks.release;
+
+    expect(release.shell).toEqual('system');
+  });
+});

--- a/test/bump-condition-shell.test.ts
+++ b/test/bump-condition-shell.test.ts
@@ -32,4 +32,18 @@ describe('bump/release tasks run under the system shell', () => {
 
     expect(release.shell).toEqual('system');
   });
+
+  test('the release task retries the bump phase exactly once on failure', () => {
+    const parent = new yarn.CdkLabsMonorepo({ name: 'monorepo', defaultReleaseBranch: 'main', release: true });
+    new yarn.TypeScriptWorkspace({ parent, name: '@cdklabs/one' });
+
+    const outdir = Testing.synth(parent);
+    const release = outdir['.projen/tasks.json'].tasks.release;
+    const bumpStep = release.steps.find((s: { exec?: string }) => s.exec?.includes('bump'));
+
+    // The bump step runs once, and on non-zero re-runs exactly once after logging.
+    expect(bumpStep.exec).toMatch(/ bump \|\| \{ echo '[^']+'; .* bump; \}$/);
+    // Exactly two invocations of the bump run (no more, no infinite loop).
+    expect(bumpStep.exec.match(/ bump(?= \|\||;)/g)).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
> Supersedes #961 (that PR was auto-closed and could not be reopened because its branch was force-pushed during this rebase). Same fix, rebased onto current `main`.

### What broke

Release `bump` tasks were intermittently skipped even when the latest commit was a normal (non-release) commit. Combined with the fail-loud guard (#960), a transient skip becomes a hard release failure; without it, it causes a missed release or a broken `^0.0.0` dependency range. Observed downstream as `@aws-cdk/service-spec-importers@0.0.133` shipping `@aws-cdk/service-spec-types: "^0.0.0"`.

### Cause

The generated `bump` task's condition is projen's `CHANGES_SINCE_LAST_RELEASE`: `git log --oneline -1 | grep -qv "chore(release):"`. projen 0.101.x evaluates task conditions through its built-in dax shell. `grep -q` closes the pipe after the first line; that early close races with `git log` still writing, and dax reports the failed write as a spurious non-zero exit (`stdin pipe broken. Invalid state: WritableStream is closed`), which the task runtime treats as "skip".

### The fix (two commits)

1. Run the generated `bump` and root `release` tasks through the system shell (`TaskShell.system()`), where the pipeline follows POSIX semantics (the status is grep's and the upstream SIGPIPE is benign), so the condition is evaluated reliably. `TaskShell` requires projen >= 0.101.0; `main` already floors projen at `>=0.101.15`, so no peer-floor change is needed on this rebase.
2. Retry the release bump phase exactly once via a single POSIX `||`-guarded command (`... bump || { echo '...'; ... bump; }`) run under the system shell. Bump is idempotent (each package's version recomputes from its git tag, and versions materialized in the first pass persist into the second), so a transient skip recovers; a second consecutive failure still exits non-zero and aborts the release.

These are interim mitigations for a projen defect; the root cause is fixed upstream in projen/projen#4819.

### Rebase note

Rebased onto current `main` (`8bd9b9d`). The only conflicts were the projen peer-version floor in `.projenrc.ts` / `.projen/deps.json` / `package.json` / `yarn.lock`; resolved by taking `main`'s higher `>=0.101.15` floor (which already satisfies the `TaskShell` requirement), so those files no longer appear in the diff. `npx projen` was re-run after the rebase; the working tree was clean (generated artifacts consistent).

### Validation

- `npx projen compile` — 0 errors (only benign JSII6 devDependency warnings).
- `npx projen eslint` — clean.
- New synth test `test/bump-condition-shell.test.ts` passes: asserts the generated bump task keeps the release condition and carries shell `system`, the root release task carries shell `system`, and the release bump step is the retry-once form (exactly two invocations with a log line between). The `cdklabs-monorepo` snapshot suite also passes.
- **Pre-existing test failures (not caused by this change):** the 4 tests in `test/gather-versions.test.ts` fail with `Task "install" failed (yarn install --check-files, exit 1)`. Verified they fail **identically on clean `main`** (`8bd9b9d`) in this sandbox — they are environmental (no network for `yarn install`) and match the #960 guard context. All other 151 unit tests pass.

### Related PRs

- Companion fail-loud guard (already merged): #960
- Upstream projen root-cause fix: https://github.com/projen/projen/pull/4819